### PR TITLE
force nightly toolchain

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
Force use of nightly toolchain so that a developer can `git clone`, then `cargo test` regardless of their default toolchain