### PR TITLE
List's `iter` can be `ExactSizeIterator`

### DIFF
--- a/starlark/src/values/types/list.rs
+++ b/starlark/src/values/types/list.rs
@@ -98,7 +98,7 @@ impl<'v> ListRef<'v> {
     }
 
     /// Iterate over the elements in the list.
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = Value<'v>> + 'a
+    pub fn iter<'a>(&'a self) -> impl ExactSizeIterator<Item = Value<'v>> + 'a
     where
         'v: 'a,
     {
@@ -322,7 +322,7 @@ impl<'v> List<'v> {
     }
 
     /// Iterate over the elements in the list.
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = Value<'v>> + 'a
+    pub fn iter<'a>(&'a self) -> impl ExactSizeIterator<Item = Value<'v>> + 'a
     where
         'v: 'a,
     {
@@ -350,7 +350,7 @@ impl<'v> Display for ListRef<'v> {
 
 impl FrozenList {
     /// Iterate over the elements in the list.
-    pub fn iter<'a, 'v>(&'a self) -> impl Iterator<Item = Value<'v>> + 'a
+    pub fn iter<'a, 'v>(&'a self) -> impl ExactSizeIterator<Item = Value<'v>> + 'a
     where
         'v: 'a,
     {


### PR DESCRIPTION
I'm toying around with making PyO3 bindings for this library and I found this helpful going from a Starlark `List` -> `PyList`.

It seems like a reasonable change since lists always know their length, and due to the use of `content.iter` there's no additional implementation burden. `ExactSizeIterator` is a strictly more confined type than `Iterator` so this is fully backwards compatible. I'm not sure if this can be applied to generators, but I should think not as an error could occur during iteration? Presumably this same change could be made to tuples and other types quite easily.

I'll get to those eventually in my gacially slow just-for-cruriosity's-sake pace, but wanted to open a PR now, as I'm not sure how often I'll tinker on this project.

Cheers