### PR TITLE
Adding ELI5 video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ This project provides a Rust implementation of the [Starlark language](https://g
 
 There are at least three implementations of Starlark, [one in Java](https://github.com/bazelbuild/starlark), [one in Go](https://github.com/google/starlark-go), and this one in Rust. We mostly follow the Starlark standard.
 
+## Learn More in This Intro Video
+
+[![Explain Like I'm 5: Starlark-Rust](https://img.youtube.com/vi/3kHER3KIPj4/0.jpg)](https://www.youtube.com/watch?v=3kHER3KIPj4)
+
 ## Features
 
 This project features:

--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ This project provides a Rust implementation of the [Starlark language](https://g
 
 There are at least three implementations of Starlark, [one in Java](https://github.com/bazelbuild/starlark), [one in Go](https://github.com/google/starlark-go), and this one in Rust. We mostly follow the Starlark standard.
 
-## Learn More in This Intro Video
+## Learn More 
+
+Watch this introductory video about Starlark-Rust from [Meta Open Source team](https://opensource.facebook.com/):
 
 [![Explain Like I'm 5: Starlark-Rust](https://img.youtube.com/vi/3kHER3KIPj4/0.jpg)](https://www.youtube.com/watch?v=3kHER3KIPj4)
+
+You can also read about the project functionalities in [this blog post](https://developers.facebook.com/blog/post/2021/04/08/rust-starlark-library/). 
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,9 @@ There are at least three implementations of Starlark, [one in Java](https://gith
 
 ## Learn More 
 
-Watch this introductory video about Starlark-Rust from [Meta Open Source team](https://opensource.facebook.com/):
+You can learn more about Starlark Rust in [this introductory video(https://www.youtube.com/watch?v=3kHER3KIPj4) from [Meta Open Source team](https://opensource.facebook.com/).
 
-[![Explain Like I'm 5: Starlark-Rust](https://img.youtube.com/vi/3kHER3KIPj4/0.jpg)](https://www.youtube.com/watch?v=3kHER3KIPj4)
-
-You can also read about the project functionalities in [this blog post](https://developers.facebook.com/blog/post/2021/04/08/rust-starlark-library/). 
+You can also read about the project functionalities in [this blog post](https://developers.facebook.com/blog/post/2021/04/08/rust-starlark-library/).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ There are at least three implementations of Starlark, [one in Java](https://gith
 
 ## Learn More 
 
-You can learn more about Starlark Rust in [this introductory video(https://www.youtube.com/watch?v=3kHER3KIPj4) from [Meta Open Source team](https://opensource.facebook.com/).
+You can learn more about Starlark Rust in [this introductory video](https://www.youtube.com/watch?v=3kHER3KIPj4) from [Meta Open Source team](https://opensource.facebook.com/).
 
 You can also read about the project functionalities in [this blog post](https://developers.facebook.com/blog/post/2021/04/08/rust-starlark-library/).
 


### PR DESCRIPTION
## Summary
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Jest](https://jestjs.io/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc.

## Test plan
![image](https://user-images.githubusercontent.com/12485205/154587505-8a4858a5-f419-445a-b3cc-4b381663d8c6.png)
