### PR TITLE
Migrate from structopt to clap v4

### DIFF
--- a/starlark/Cargo.toml
+++ b/starlark/Cargo.toml
@@ -60,7 +60,7 @@ argfile = "0.1.0"
 num-bigint = "0.4.3"
 num-traits = "0.2"
 inventory = "0.1.10"
-clap = { version = "3.2.22", features = ["derive"] }
+clap = { version = "4.0.7", features = ["derive", "wrap_help", "cargo"] }
 
 [dev-dependencies]
 rand = { version = "0.8.4", features = ["small_rng"] }

--- a/starlark/Cargo.toml
+++ b/starlark/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/facebookexperimental/starlark-rust"
 authors = [
     "Damien Martin-Guillerez <dmarting@google.com>",
     "Stepan Koltsov <stepan.koltsov@gmail.com>",
-    "Facebook"
+    "Facebook",
 ]
 build = "build.rs"
 keywords = ["starlark", "skylark", "bazel", "language", "interpreter"]
@@ -41,7 +41,6 @@ gazebo.features = ["str_pattern_extensions"]
 gazebo_lint.version = "0.1"
 gazebo_lint.optional = true
 # @oss-disable: gazebo_lint.path = "../../gazebo_lint/gazebo_lint"
-structopt = "0.3.23"
 walkdir = "2.3"
 serde = { version = "1.0", features = ["derive"] }
 logos = "0.12"
@@ -61,9 +60,10 @@ argfile = "0.1.0"
 num-bigint = "0.4.3"
 num-traits = "0.2"
 inventory = "0.1.10"
+clap = { version = "3.2.22", features = ["derive"] }
 
 [dev-dependencies]
-rand      = { version = "0.8.4", features = ["small_rng"] }
+rand = { version = "0.8.4", features = ["small_rng"] }
 
 [features]
 # @oss-disable: default = ["gazebo_lint"]

--- a/starlark/bin/main.rs
+++ b/starlark/bin/main.rs
@@ -32,7 +32,7 @@ use std::fmt::Display;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use clap::StructOpt;
+use clap::Parser;
 use eval::Context;
 use gazebo::prelude::*;
 use itertools::Either;
@@ -49,10 +49,10 @@ mod dap;
 mod eval;
 mod types;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "starlark", about = "Evaluate Starlark code", version)]
+#[derive(Debug, Parser)]
+#[command(name = "starlark", about = "Evaluate Starlark code", version)]
 struct Args {
-    #[structopt(
+    #[arg(
         long = "lsp",
         help = "Start an LSP server.",
         conflicts_with_all = &[
@@ -65,7 +65,7 @@ struct Args {
     )]
     lsp: bool,
 
-    #[structopt(
+    #[arg(
         long = "dap",
         help = "Start a DAP server.",
         // Conflicts with all options.
@@ -81,50 +81,45 @@ struct Args {
     )]
     dap: bool,
 
-    #[structopt(
+    #[arg(
         long = "check",
         help = "Run checks and lints.",
         conflicts_with_all = &["lsp", "dap"],
     )]
     check: bool,
 
-    #[structopt(
+    #[arg(
         long = "json",
         help = "Show output as JSON lines.",
         conflicts_with_all = &["lsp", "dap"],
     )]
     json: bool,
 
-    #[structopt(
+    #[arg(
         long = "extension",
         help = "File extension when searching directories."
     )]
     extension: Option<String>,
 
-    #[structopt(
-        long = "prelude",
-        help = "Files to load in advance.",
-        multiple_values = true
-    )]
+    #[arg(long = "prelude", help = "Files to load in advance.", num_args = 1..)]
     prelude: Vec<PathBuf>,
 
-    #[structopt(
+    #[arg(
         long = "expression",
         short = 'e',
         id = "evaluate",
         value_name = "EXPRESSION",
         help = "Expressions to evaluate.",
         conflicts_with_all = &["lsp", "dap"],
-        multiple_values = true,
+        num_args = 1..,
     )]
     evaluate: Vec<String>,
 
-    #[structopt(
+    #[arg(
         id = "files",
         value_name = "FILE",
         help = "Files to evaluate.",
         conflicts_with_all = &["lsp", "dap"],
-        multiple_values = true,
     )]
     files: Vec<PathBuf>,
 }

--- a/starlark/bin/main.rs
+++ b/starlark/bin/main.rs
@@ -32,6 +32,8 @@ use std::fmt::Display;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use clap::AppSettings;
+use clap::StructOpt;
 use eval::Context;
 use gazebo::prelude::*;
 use itertools::Either;
@@ -39,8 +41,6 @@ use starlark::errors::EvalMessage;
 use starlark::errors::EvalSeverity;
 use starlark::lsp;
 use starlark::read_line::ReadLine;
-use structopt::clap::AppSettings;
-use structopt::StructOpt;
 use walkdir::WalkDir;
 
 use crate::eval::ContextMode;
@@ -61,7 +61,6 @@ struct Args {
         long = "lsp",
         help = "Start an LSP server.",
         conflicts_with_all = &[
-            "interactive",
             "dap",
             "check",
             "json",
@@ -76,7 +75,6 @@ struct Args {
         help = "Start a DAP server.",
         // Conflicts with all options.
         conflicts_with_all = &[
-            "interactive",
             "lsp",
             "check",
             "json",
@@ -108,22 +106,26 @@ struct Args {
     )]
     extension: Option<String>,
 
-    #[structopt(long = "prelude", help = "Files to load in advance.")]
+    #[structopt(long = "prelude", help = "Files to load in advance.", multiple = true)]
     prelude: Vec<PathBuf>,
 
     #[structopt(
         long = "expression",
-        short = "e",
-        name = "EXPRESSION",
+        short = 'e',
+        id = "evaluate",
+        value_name = "EXPRESSION",
         help = "Expressions to evaluate.",
         conflicts_with_all = &["lsp", "dap"],
+        multiple = true,
     )]
     evaluate: Vec<String>,
 
     #[structopt(
-        name = "FILE",
+        id = "files",
+        value_name = "FILE",
         help = "Files to evaluate.",
         conflicts_with_all = &["lsp", "dap"],
+        multiple = true,
     )]
     files: Vec<PathBuf>,
 }

--- a/starlark/bin/main.rs
+++ b/starlark/bin/main.rs
@@ -32,7 +32,6 @@ use std::fmt::Display;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use clap::AppSettings;
 use clap::StructOpt;
 use eval::Context;
 use gazebo::prelude::*;
@@ -51,11 +50,7 @@ mod eval;
 mod types;
 
 #[derive(Debug, StructOpt)]
-#[structopt(
-    name = "starlark",
-    about = "Evaluate Starlark code",
-    global_settings(&[AppSettings::ColoredHelp]),
-)]
+#[structopt(name = "starlark", about = "Evaluate Starlark code", version)]
 struct Args {
     #[structopt(
         long = "lsp",
@@ -106,7 +101,11 @@ struct Args {
     )]
     extension: Option<String>,
 
-    #[structopt(long = "prelude", help = "Files to load in advance.", multiple = true)]
+    #[structopt(
+        long = "prelude",
+        help = "Files to load in advance.",
+        multiple_values = true
+    )]
     prelude: Vec<PathBuf>,
 
     #[structopt(
@@ -116,7 +115,7 @@ struct Args {
         value_name = "EXPRESSION",
         help = "Expressions to evaluate.",
         conflicts_with_all = &["lsp", "dap"],
-        multiple = true,
+        multiple_values = true,
     )]
     evaluate: Vec<String>,
 
@@ -125,7 +124,7 @@ struct Args {
         value_name = "FILE",
         help = "Files to evaluate.",
         conflicts_with_all = &["lsp", "dap"],
-        multiple = true,
+        multiple_values = true,
     )]
     files: Vec<PathBuf>,
 }
@@ -219,7 +218,7 @@ fn main() -> anyhow::Result<()> {
     gazebo::terminate_on_panic();
 
     let args = argfile::expand_args(argfile::parse_fromfile, argfile::PREFIX)?;
-    let args: Args = Args::from_iter(args);
+    let args: Args = Args::parse_from(args);
     if args.dap {
         dap::server();
     } else {


### PR DESCRIPTION
This removes the ansi_term dependency and resolves #55

The only real noticeable change is that the output of `--help` looks different. I think updated color support is in the works...
| Old | New |
|---|---|
|![image](https://user-images.githubusercontent.com/40507205/193409813-ed4eb419-2a2f-4cbb-9cb3-63616cf75ef9.png)|![image](https://user-images.githubusercontent.com/40507205/193409932-d7904356-4f41-4594-9b39-484fa7d6dd20.png)|

After some quick testing, all functionality appears to be the same, but any testing would be appreciated as I am still inexperienced with this project. Let me know if you have any feedback or suggested changes!

------

_I'm participating in [Hacktoberfest 2022](https://hacktoberfest.com) and if this PR is approved it, it would be greatly appreciated if the PR could be labelled `hacktoberfest-accepted`, or even the repository labelled as `hacktoberfest` to allow PRs in this repository to count towards the competition!_