### PR TITLE
Do not check for avisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
     - uses: EmbarkStudios/cargo-deny-action@v1
       if: matrix.os == 'ubuntu-latest' # Only works on Linux
       with:
-        command: check advisories bans sources
+        command: check bans sources


### PR DESCRIPTION
We have allocative in the workspace. Allocative implements bindings for ownning_ref. And the latter has known issues like:

https://rustsec.org/advisories/RUSTSEC-2022-0040

This linter does not provide much value, so just disable it.