### PR TITLE
Feature flags to make lsp and readline support optional

### DIFF
--- a/starlark/Cargo.toml
+++ b/starlark/Cargo.toml
@@ -41,9 +41,9 @@ walkdir = "2.3"
 serde = { version = "1.0", features = ["derive"] }
 logos = "0.12"
 serde_json = "1.0"
-rustyline = "7.1"
+rustyline = {version = "7.1", optional = true}
 maplit = "1.0.2"
-lsp-server = "0.5"
+lsp-server = {version = "0.5", optional = true}
 lsp-types = "0.93.0"
 memchr = "2.4.1"
 debugserver-types = "0.5.0"
@@ -56,9 +56,14 @@ argfile = "0.1.0"
 num-bigint = "0.4.3"
 num-traits = "0.2"
 inventory = "0.1.9"
-clap = { version = "4.0.7", features = ["derive", "wrap_help"] }
+clap = { version = "4.0.7", features = ["derive", "wrap_help"], optional = true }
 
 allocative = { workspace = true, features = ["bumpalo", "hashbrown", "num-bigint"] }
+
+[features]
+default = ["console"]
+console = ["dep:rustyline"]
+lsp = ["dep:lsp-server", "dep:clap"]
 
 [dev-dependencies]
 rand = { version = "0.8.4", features = ["small_rng"] }
@@ -66,3 +71,4 @@ rand = { version = "0.8.4", features = ["small_rng"] }
 [[bin]]
 name = "starlark"
 path = "bin/main.rs"
+required-features = ["console", "lsp"]

--- a/starlark/src/eval/runtime/evaluator.rs
+++ b/starlark/src/eval/runtime/evaluator.rs
@@ -61,7 +61,6 @@ use crate::eval::runtime::slots::LocalSlotId;
 use crate::eval::CallStack;
 use crate::eval::FileLoader;
 use crate::stdlib::breakpoint::BreakpointConsole;
-use crate::stdlib::breakpoint::RealBreakpointConsole;
 use crate::stdlib::extra::PrintHandler;
 use crate::stdlib::extra::StderrPrintHandler;
 use crate::values::function::NativeFunction;
@@ -359,7 +358,9 @@ impl<'v, 'a> Evaluator<'v, 'a> {
     /// Enable interactive `breakpoint()`. When enabled, `breakpoint()`
     /// reads commands from stdin and write to stdout.
     /// When disabled (default), `breakpoint()` function results in error.
+    #[cfg(feature = "console")]
     pub fn enable_terminal_breakpoint_console(&mut self) {
+        use crate::read_line::RealBreakpointConsole;
         self.breakpoint_handler = Some(RealBreakpointConsole::factory());
     }
 

--- a/starlark/src/lib.rs
+++ b/starlark/src/lib.rs
@@ -396,8 +396,10 @@ pub mod docs;
 pub mod environment;
 pub mod errors;
 pub mod eval;
+#[cfg(feature = "lsp")]
 pub mod lsp;
 mod private;
+#[cfg(feature = "console")]
 pub mod read_line;
 mod sealed;
 pub(crate) mod slice_vec_ext;

--- a/starlark/src/stdlib/breakpoint.rs
+++ b/starlark/src/stdlib/breakpoint.rs
@@ -25,7 +25,6 @@ use thiserror::Error;
 use crate as starlark;
 use crate::environment::GlobalsBuilder;
 use crate::eval::Evaluator;
-use crate::read_line::ReadLine;
 use crate::syntax::AstModule;
 use crate::syntax::Dialect;
 use crate::values::none::NoneType;
@@ -39,31 +38,6 @@ pub(crate) trait BreakpointConsole {
     /// Return `None` on EOF.
     fn read_line(&mut self) -> anyhow::Result<Option<String>>;
     fn println(&mut self, line: &str);
-}
-
-/// Breakpoint handler implemented with `rustyline`.
-pub(crate) struct RealBreakpointConsole {
-    read_line: ReadLine,
-}
-
-impl BreakpointConsole for RealBreakpointConsole {
-    fn read_line(&mut self) -> anyhow::Result<Option<String>> {
-        self.read_line.read_line("$> ")
-    }
-
-    fn println(&mut self, line: &str) {
-        eprintln!("{}", line);
-    }
-}
-
-impl RealBreakpointConsole {
-    pub(crate) fn factory() -> Box<dyn Fn() -> anyhow::Result<Box<dyn BreakpointConsole>>> {
-        Box::new(|| {
-            Ok(Box::new(RealBreakpointConsole {
-                read_line: ReadLine::new("STARLARK_RUST_DEBUGGER_HISTFILE")?,
-            }))
-        })
-    }
 }
 
 /// Is debugging allowed or not? After the user hits Ctrl-C they probably


### PR DESCRIPTION
This diff moves support for readline (used by the breakpoint console)
and the LSP server behind a cargo feature.  Readline is enabled in the
lib by default to preserve debugging when embedding, while lsp is only
enabled when building the starlark binary.

The motivation is to support a wasm32-unknown-unknown build of
starlark.
