### PR TITLE
Parameter autocomplete improvements

### DIFF
--- a/starlark/src/lsp/inspect.rs
+++ b/starlark/src/lsp/inspect.rs
@@ -268,13 +268,11 @@ impl AstModule {
                     // No matches? We might be in between empty braces (new function call),
                     // e.g. `foo(|)`. However, we don't want to offer completions for
                     // when the cursor is at the very end of the function call, e.g. `foo()|`.
-                    return Some(if args.is_empty() && span.end() != position {
+                    return Some(if span.end() != position {
                         AutocompleteType::Parameter {
                             function_name: name.to_string(),
                             function_name_span: codemap.resolve_span(name.span),
                         }
-                    } else if !args.is_empty() {
-                        AutocompleteType::Default
                     } else {
                         // Don't offer completions right after the function call.
                         AutocompleteType::None

--- a/starlark/src/lsp/server.rs
+++ b/starlark/src/lsp/server.rs
@@ -406,6 +406,8 @@ impl<T: LspContext> Backend<T> {
                     "[".to_owned(),
                     // e.g. string literal (load path, target name)
                     "\"".to_owned(),
+                    // don't lose autocomplete when typing a space, e.g. after a comma
+                    " ".to_owned(),
                 ]),
                 ..Default::default()
             }),

--- a/starlark/src/lsp/server.rs
+++ b/starlark/src/lsp/server.rs
@@ -763,12 +763,15 @@ impl<T: LspContext> Backend<T> {
                         workspace_root.as_deref(),
                     )),
                     Some(AutocompleteType::Parameter {
-                        function_name_span, ..
+                        function_name_span,
+                        previously_used_named_parameters,
+                        ..
                     }) => Some(
                         self.parameter_name_options(
                             function_name_span,
                             &document,
                             &uri,
+                            &previously_used_named_parameters,
                             workspace_root.as_deref(),
                         )
                         .chain(self.default_completion_options(


### PR DESCRIPTION
Some autocomplete improvements aimed at typing parameters:

- Correctly offer parameter completion options when typing a new parameter after the first one.
- Omit already used parameter names as options.
- Re-offer completion when typing a space after a comma in a function call (and other such cases).