### PR TITLE
feat: graceful parsing of `load` statements

### DIFF
--- a/starlark/src/syntax/ast.rs
+++ b/starlark/src/syntax/ast.rs
@@ -61,7 +61,6 @@ pub(crate) type Clause = ClauseP<AstNoPayload>;
 pub(crate) type ForClause = ForClauseP<AstNoPayload>;
 pub(crate) type Argument = ArgumentP<AstNoPayload>;
 pub(crate) type Parameter = ParameterP<AstNoPayload>;
-pub(crate) type Load = LoadP<AstNoPayload>;
 pub(crate) type Stmt = StmtP<AstNoPayload>;
 
 // Boxed types used for storing information from the parsing will be used

--- a/starlark/src/syntax/grammar.lalrpop
+++ b/starlark/src/syntax/grammar.lalrpop
@@ -192,15 +192,8 @@ ExprStmt: AstStmt = ASTS<ExprStmt_>;
 ExprStmt_: Stmt = <Test> => Stmt::Expression(<>);
 
 LoadStmt: AstStmt = ASTS<LoadStmt_>;
-LoadStmt_: Stmt = LoadStmtInner => Stmt::Load(<>);
-
-LoadStmtInner: Load = "load" "(" <module:string> <args:("," <LoadStmtSyms>)+> ","? ")" => {
-    Load {
-        module,
-        args,
-        payload: (),
-    }
-};
+LoadStmt_: Stmt = "load" "(" <module:string> <args:("," <LoadStmtSyms>)*> ","? ")" 
+        => grammar_util::check_load(<>, state);
 
 LoadStmtBindingName: AstString = <identifier> "=";
 

--- a/starlark/src/syntax/grammar_util.rs
+++ b/starlark/src/syntax/grammar_util.rs
@@ -17,6 +17,8 @@
 
 //! Code called by the parser to handle complex cases not handled by the grammar.
 
+use super::ast::AstAssignIdent;
+use super::load::check_load_statement;
 use crate::codemap::CodeMap;
 use crate::codemap::Pos;
 use crate::codemap::Span;
@@ -41,6 +43,7 @@ use crate::syntax::ast::ExprP;
 use crate::syntax::ast::FStringP;
 use crate::syntax::ast::IdentP;
 use crate::syntax::ast::LambdaP;
+use crate::syntax::ast::LoadP;
 use crate::syntax::ast::Stmt;
 use crate::syntax::ast::StmtP;
 use crate::syntax::ast::ToAst;
@@ -172,6 +175,22 @@ pub(crate) fn check_def(
         params,
         return_type,
         body: Box::new(stmts),
+        payload: (),
+    })
+}
+
+pub(crate) fn check_load(
+    module: AstString,
+    args: Vec<(AstAssignIdent, AstString)>,
+    parser_state: &mut ParserState,
+) -> Stmt {
+    if let Err(e) = check_load_statement(&module, &args, &parser_state.codemap) {
+        parser_state.errors.push(e);
+    }
+
+    Stmt::Load(LoadP {
+        module,
+        args,
         payload: (),
     })
 }

--- a/starlark/src/syntax/load.rs
+++ b/starlark/src/syntax/load.rs
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 The Starlark in Rust Authors.
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use starlark_syntax::codemap::CodeMap;
+
+use super::ast::AstAssignIdent;
+use super::ast::AstString;
+use crate::eval::compiler::eval_exception::EvalException;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum LoadError {
+    #[error("a `load` statement requires at least two arguments")]
+    LoadRequiresAtLeastTwoArguments,
+}
+
+pub(crate) fn check_load_statement(
+    module: &AstString,
+    args: &[(AstAssignIdent, AstString)],
+    codemap: &CodeMap,
+) -> Result<(), EvalException> {
+    match args.is_empty() {
+        true => Err(EvalException::new(
+            LoadError::LoadRequiresAtLeastTwoArguments.into(),
+            module.span,
+            codemap,
+        )),
+        false => Ok(()),
+    }
+}

--- a/starlark/src/syntax/mod.rs
+++ b/starlark/src/syntax/mod.rs
@@ -32,6 +32,7 @@ pub(crate) mod grammar_util;
 pub(crate) mod lexer;
 #[cfg(test)]
 mod lexer_tests;
+pub(crate) mod load;
 pub(crate) mod module;
 pub(crate) mod parser;
 pub(crate) mod payload_map;


### PR DESCRIPTION
Don't produce a parse error on `load` statements with only one argument, issue an error to the parser state instead. This allow the LSP to correctly detect when the cursor is inside the first argument to a `load` statement, and offer autocomplete options accordingly (see also #82).