### PR TITLE
fix: jump to definition on dotted definition

### DIFF
--- a/starlark/src/lsp/server.rs
+++ b/starlark/src/lsp/server.rs
@@ -687,15 +687,17 @@ impl<T: LspContext> Backend<T> {
                     // so it's simpler to do the lookup here, rather than threading a ton of
                     // information through.
                     Definition::Dotted(DottedDefinition {
-                        root_definition_location: IdentifierDefinition::Location { .. },
+                        root_definition_location: IdentifierDefinition::Location { destination, .. },
                         segments,
                         ..
                     }) => {
-                        let member_location = ast.find_exported_symbol_and_member(
-                            segments.first().expect("at least one segment").as_str(),
-                            segments.get(1).expect("at least two segments").as_str(),
-                        );
-                        Self::location_link(source, &uri, member_location.unwrap_or_default())?
+                        let member_location = ast
+                            .find_exported_symbol_and_member(
+                                segments.first().expect("at least one segment").as_str(),
+                                segments.get(1).expect("at least two segments").as_str(),
+                            )
+                            .unwrap_or(destination);
+                        Self::location_link(source, &uri, member_location)?
                     }
                     Definition::Dotted(definition) => self.resolve_definition_location(
                         definition.root_definition_location,


### PR DESCRIPTION
In cases where you try to go-to-definition on a dotted identifier, e.g. `foo.bar.baz`, the LSP will try to find where `foo` is defined, and check if it's a `struct` definition with a property named `bar`, and jump to that. However, in cases where this location cannot be resolved, an `unwrap_or_default` would result in jumping to to the top of the file. Instead, in such cases, jump to the definition of the variable `foo` itself, which is better than jumping to the top of the file.

Fixes #90