### PR TITLE
Bazel: Fix relative go to definition in external repositories

### DIFF
--- a/starlark_bin/bin/bazel.rs
+++ b/starlark_bin/bin/bazel.rs
@@ -423,10 +423,8 @@ impl BazelContext {
                 // system information to check if we're in a known remote repository, and what the
                 // root is. Fall back to the `workspace_root` otherwise.
                 ("", LspUrl::File(current_file)) => {
-                    if let Some((_, remote_repository_root)) =
-                        self.get_repository_for_path(current_file)
-                    {
-                        Some(Cow::Borrowed(remote_repository_root))
+                    if let Some((repository_name, _)) = self.get_repository_for_path(current_file) {
+                        self.get_repository_path(&repository_name).map(Cow::Owned)
                     } else {
                         workspace_root.map(Cow::Borrowed)
                     }


### PR DESCRIPTION
For relative loads from external repositories, the resolve root was calcualated incorrectly. Instead of removing the path of the file within the external repository, it only kept this part. For example if the current file was `$(bazel info output_base)/external/foo/bar/BUILD`, it would compute the resolve root as `bar/BUILD`, whereas it needs to be `$(bazel info output_base)/external/foo`.