### PR TITLE
Re-enable completions

### DIFF
--- a/starlark_lsp/src/server.rs
+++ b/starlark_lsp/src/server.rs
@@ -47,6 +47,7 @@ use lsp_types::request::GotoDefinition;
 use lsp_types::request::HoverRequest;
 use lsp_types::CompletionItem;
 use lsp_types::CompletionItemKind;
+use lsp_types::CompletionOptions;
 use lsp_types::CompletionParams;
 use lsp_types::CompletionResponse;
 use lsp_types::DefinitionOptions;
@@ -405,6 +406,7 @@ impl<T: LspContext> Backend<T> {
         ServerCapabilities {
             text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
             definition_provider,
+            completion_provider: Some(CompletionOptions::default()),
             hover_provider: Some(HoverProviderCapability::Simple(true)),
             ..ServerCapabilities::default()
         }


### PR DESCRIPTION
4be1b3bbf38dbddfca9aabacbff82a644681ae9d disabled autocomplete by passing no completion provider to the client. However, I think the intention was to just remove the triggers, not disable all autocomplete. This re-enables this functionality.

Fixes #112