### PR TITLE
feat: expose RecordType from record_type module

### DIFF
--- a/starlark/src/values/types/record.rs
+++ b/starlark/src/values/types/record.rs
@@ -48,4 +48,5 @@ pub(crate) mod matcher;
 pub(crate) mod record_type;
 pub(crate) mod ty_record_type;
 
+pub use crate::values::record::record_type::RecordType;
 pub use crate::values::record::instance::Record;


### PR DESCRIPTION
This is required in order to accept arguments that are type of `record`.

```
fn task<'v>(
      #[starlark(require = named, default = NoneOr::None)] binding: NoneOr<RecordType>,
)
```