### PR TITLE
Add start/end params to str.startswith/endswith, allow named default in dict.pop

### DIFF
--- a/starlark/src/values/types/dict/methods.rs
+++ b/starlark/src/values/types/dict/methods.rs
@@ -169,7 +169,7 @@ pub(crate) fn dict_methods(registry: &mut MethodsBuilder) {
     fn pop<'v>(
         this: Value<'v>,
         #[starlark(require = pos)] key: Value<'v>,
-        #[starlark(require = pos)] default: Option<Value<'v>>,
+        default: Option<Value<'v>>,
     ) -> starlark::Result<Value<'v>> {
         let mut me = DictMut::from_value(this)?;
         match me.aref.remove_hashed(key.get_hashed()?) {
@@ -383,6 +383,14 @@ mod tests {
     fn test_error_codes() {
         assert::fail(r#"x = {"one": 1}; x.pop("four")"#, "not found");
         assert::fail("x = {}; x.popitem()", "empty");
+    }
+
+    #[test]
+    fn test_dict_pop_default_named() {
+        // Bazel compatibility: dict.pop() accepts `default` as a named kwarg
+        assert::is_true(r#"{"a": 1}.pop("b", default = None) == None"#);
+        assert::is_true(r#"{"a": 1}.pop("a", default = 99) == 1"#);
+        assert::is_true(r#"{"a": 1}.pop("b", default = 42) == 42"#);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR makes three Bazel-compatible improvements to Starlark built-in methods:

1. **`str.startswith(prefix[, start[, end]])`** — Add optional `start` and `end` parameters, matching the [Starlark spec](https://github.com/bazelbuild/starlark/blob/master/spec.md#string%C2%B7startswith) and Python semantics. The substring `s[start:end]` is tested instead of the full string.

2. **`str.endswith(suffix[, start[, end]])`** — Same as above for `endswith()`.

3. **`dict.pop(key[, default])`** — Allow `default` to be passed as a named keyword argument (e.g., `d.pop("key", default=None)`), not just positional. This matches Bazel's Java Starlark implementation and Python's `dict.pop()`.

## Motivation

These changes are needed for Bazel compatibility. Real-world Bazel BUILD files and `.bzl` macros use these features extensively:

```python
# startswith with start/end (common in monorepo BUILD files)
[b for b in GLOBAL_BINARIES if b.startswith("//", 0, 2)]

# dict.pop with named default (common in rule macros)  
workdir = kwargs.pop("workdir", default = None)
```

## Related Issues

- **[bazelbuild/starlark#56](https://github.com/bazelbuild/starlark/issues/56)** — The Starlark spec was updated to include `start`/`end` params for `startswith`/`endswith`, but `starlark-rust` never implemented them.
- **Conformance test suite inconsistency** — The [bazelbuild/starlark conformance tests](https://github.com/bazelbuild/starlark/blob/master/test_suite/testdata/go/dict.star) document this with: `# _inconsistency_: rust fails when default=None`

## Implementation Details

### `startswith` / `endswith`

Reuses the existing `convert_str_indices` infrastructure (already used by `find()`, `count()`, `index()`, `rfind()`, `rindex()`) to slice the string before testing. Supports both single string and tuple-of-strings prefix/suffix arguments.

### `dict.pop`

Removes `#[starlark(require = pos)]` from the `default` parameter, allowing it to be passed as either positional or named. The `key` parameter remains positional-only.

## Testing

- All 981 existing tests pass (828 lib + 153 doc)
- New tests added for each change:
  - `test_startswith_with_start_end` — 7 assertions covering basic, negative indices, and tuple prefix
  - `test_endswith_with_start_end` — 4 assertions covering basic, negative indices, and tuple suffix
  - `test_dict_pop_default_named` — 3 assertions covering missing key, existing key, and fallback value