### PR TITLE
feat: implement bytes type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 Cargo.lock
 *.wasm
+.DS_Store

--- a/starlark/src/analysis/dubious.rs
+++ b/starlark/src/analysis/dubious.rs
@@ -65,6 +65,7 @@ fn duplicate_dictionary_key(module: &AstModule, res: &mut Vec<LintT<Dubious>>) {
         Int(StarlarkInt),
         Float(u64),
         String(&'a str),
+        Bytes(&'a [u8]),
         Identifier(&'a str),
     }
 
@@ -85,6 +86,7 @@ fn duplicate_dictionary_key(module: &AstModule, res: &mut Vec<LintT<Dubious>>) {
                     }
                 }
                 AstLiteral::String(x) => Some((Key::String(&x.node), x.span)),
+                AstLiteral::Bytes(x) => Some((Key::Bytes(&x.node), x.span)),
                 AstLiteral::Ellipsis => None,
             },
             Expr::Identifier(x) => Some((Key::Identifier(&x.node.ident), x.span)),
@@ -187,6 +189,22 @@ mod tests {
             &[
                 "\"no1\"", "42", "\"no2\"", "123", "0.25", "no3", "no3", "no4"
             ]
+        );
+    }
+
+    #[test]
+    fn test_lint_duplicate_bytes_keys() {
+        let m = module(
+            r#"
+{b"a": 1, b"a": 2}
+{b"x": 1, b"y": 2, b"x": 3}
+"#,
+        );
+        let mut res = Vec::new();
+        duplicate_dictionary_key(&m, &mut res);
+        assert_eq!(
+            res.map(|x| x.problem.about()),
+            &["b\"a\"", "b\"x\""]
         );
     }
 

--- a/starlark/src/eval/compiler/expr.rs
+++ b/starlark/src/eval/compiler/expr.rs
@@ -1051,6 +1051,11 @@ impl AstLiteralCompile for AstLiteral {
             AstLiteral::Int(i) => heap.alloc(StarlarkInt::from(i.node.clone())),
             AstLiteral::Float(f) => heap.alloc(f.node),
             AstLiteral::String(x) => heap.alloc(x.node.as_str()),
+            AstLiteral::Bytes(b) => {
+                heap.alloc(crate::values::types::bytes::value::StarlarkBytes::new(
+                    &b.node,
+                ))
+            }
             AstLiteral::Ellipsis => heap.alloc(Ellipsis),
         }
     }

--- a/starlark/src/stdlib/funcs/globals.rs
+++ b/starlark/src/stdlib/funcs/globals.rs
@@ -26,11 +26,13 @@ use crate::values::none::globals::register_none;
 use crate::values::range::globals::register_range;
 use crate::values::string::globals::register_str;
 use crate::values::tuple::globals::register_tuple;
+use crate::values::types::bytes::globals::register_bytes;
 use crate::values::types::dict::globals::register_dict;
 use crate::values::types::list::globals::register_list;
 use crate::values::types::num::globals::register_num;
 
 pub(crate) fn register_globals(globals: &mut GlobalsBuilder) {
+    register_bytes(globals);
     register_list(globals);
     register_tuple(globals);
     register_dict(globals);

--- a/starlark/src/typing/ctx.rs
+++ b/starlark/src/typing/ctx.rs
@@ -437,6 +437,7 @@ impl TypingContext<'_> {
                 AstLiteral::Int(_) => Ok(Ty::int()),
                 AstLiteral::Float(_) => Ok(Ty::float()),
                 AstLiteral::String(_) => Ok(Ty::string()),
+                AstLiteral::Bytes(_) => Ok(Ty::starlark_value::<crate::values::types::bytes::value::StarlarkBytes>()),
                 AstLiteral::Ellipsis => Ok(Ty::any()),
             },
             ExprP::Not(x) => {

--- a/starlark/src/values.rs
+++ b/starlark/src/values.rs
@@ -84,6 +84,7 @@ pub use crate::values::trace::Trace;
 pub use crate::values::traits::ComplexValue;
 pub use crate::values::traits::StarlarkValue;
 pub use crate::values::types::any;
+pub use crate::values::types::bytes;
 pub use crate::values::types::any_complex;
 pub use crate::values::types::array;
 pub use crate::values::types::bool;

--- a/starlark/src/values/layout/value.rs
+++ b/starlark/src/values/layout/value.rs
@@ -838,12 +838,11 @@ impl<'v> Value<'v> {
     }
 
     /// Implement the `str()` function - converts a string value to itself,
-    /// otherwise uses `repr()`.
+    /// otherwise calls `collect_str()` (which handles bytes, etc.).
     pub fn to_str(self) -> String {
-        match self.unpack_str() {
-            None => self.to_repr(),
-            Some(s) => s.to_owned(),
-        }
+        let mut s = String::new();
+        self.collect_str(&mut s);
+        s
     }
 
     /// Implement the `repr()` function.
@@ -1319,11 +1318,7 @@ pub trait ValueLike<'v>:
 
     /// `str(x)`.
     fn collect_str(self, collector: &mut String) {
-        if let Some(s) = self.to_value().unpack_str() {
-            collector.push_str(s);
-        } else {
-            self.collect_repr(collector);
-        }
+        self.collect_repr(collector);
     }
 
     /// `x == other`.
@@ -1403,6 +1398,22 @@ impl<'v> ValueLike<'v> for Value<'v> {
         }
     }
 
+    fn collect_str(self, collector: &mut String) {
+        // Fast path: strings don't need cycle detection or vtable dispatch.
+        if let Some(s) = self.unpack_starlark_str() {
+            collector.push_str(s.as_str());
+            return;
+        }
+        match repr_stack_push(self) {
+            Ok(_guard) => {
+                self.get_ref().collect_str(collector);
+            }
+            Err(..) => {
+                self.get_ref().collect_repr_cycle(collector);
+            }
+        }
+    }
+
     fn write_hash(self, hasher: &mut StarlarkHasher) -> crate::Result<()> {
         self.get_ref().write_hash(hasher)
     }
@@ -1443,6 +1454,11 @@ impl<'v> ValueLike<'v> for FrozenValue {
     #[inline]
     fn collect_repr(self, collector: &mut String) {
         self.to_value().collect_repr(collector)
+    }
+
+    #[inline]
+    fn collect_str(self, collector: &mut String) {
+        self.to_value().collect_str(collector)
     }
 
     #[inline]

--- a/starlark/src/values/layout/vtable.rs
+++ b/starlark/src/values/layout/vtable.rs
@@ -514,6 +514,11 @@ impl<'v> AValueDyn<'v> {
     }
 
     #[inline]
+    pub(crate) fn collect_str(self, collector: &mut String) {
+        (self.vtable.starlark_value.collect_str)(self.value, collector)
+    }
+
+    #[inline]
     pub(crate) fn downcast_ref<T: StarlarkValue<'v>>(self) -> Option<&'v T> {
         if self.vtable.static_type_of_value.get() == T::static_type_id() {
             // SAFETY: just checked whether we are pointing to the correct type.

--- a/starlark/src/values/traits.rs
+++ b/starlark/src/values/traits.rs
@@ -367,6 +367,13 @@ pub trait StarlarkValue<'v>:
         write!(collector, "<{}...>", Self::TYPE).unwrap()
     }
 
+    /// Return a string representation of self, as returned by the `str()` function.
+    /// Defaults to `collect_repr`. Override to provide a different string representation
+    /// for `str()` vs `repr()` (e.g. bytes decodes as UTF-8 for `str()`).
+    fn collect_str(&self, collector: &mut String) {
+        self.collect_repr(collector)
+    }
+
     /// String used when printing call stack. `repr(self)` by default.
     fn name_for_call_stack(&self, me: Value<'v>) -> String {
         me.to_repr()

--- a/starlark/src/values/types.rs
+++ b/starlark/src/values/types.rs
@@ -21,6 +21,7 @@ pub mod any_complex;
 pub mod array;
 pub mod bigint;
 pub mod bool;
+pub mod bytes;
 pub mod dict;
 pub(crate) mod ellipsis;
 pub mod enumeration;

--- a/starlark/src/values/types/bytes/globals.rs
+++ b/starlark/src/values/types/bytes/globals.rs
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 The Starlark in Rust Authors.
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use starlark_derive::starlark_module;
+
+use crate as starlark;
+use crate::environment::GlobalsBuilder;
+use crate::values::Heap;
+use crate::values::Value;
+use crate::values::types::bytes::value::StarlarkBytes;
+
+#[starlark_module]
+pub(crate) fn register_bytes(globals: &mut GlobalsBuilder) {
+    /// [bytes](
+    /// https://github.com/bazelbuild/starlark/blob/master/spec.md#bytes
+    /// ): construct a bytes value.
+    ///
+    /// `bytes(x)` converts its argument to a `bytes` value.
+    ///
+    /// If `x` is already a `bytes` value, the result is `x`.
+    ///
+    /// If `x` is a string, its UTF-8 encoding is returned.
+    ///
+    /// If `x` is an iterable of integers (each in 0–255), the bytes are
+    /// constructed from those integer values.
+    ///
+    /// ```
+    /// # starlark::assert::all_true(r#"
+    /// bytes(b"hello") == b"hello"
+    /// bytes("hello") == b"hello"
+    /// bytes([104, 101, 108, 108, 111]) == b"hello"
+    /// # "#);
+    /// ```
+    #[starlark(as_type = StarlarkBytes)]
+    fn bytes<'v>(
+        #[starlark(require = pos)] x: Value<'v>,
+        heap: Heap<'v>,
+    ) -> anyhow::Result<Value<'v>> {
+        if StarlarkBytes::from_value(x).is_some() {
+            return Ok(x);
+        }
+        if let Some(s) = x.unpack_str() {
+            return Ok(heap.alloc(StarlarkBytes::new(s.as_bytes())));
+        }
+        // Try iterating as a sequence of ints
+        let mut result = Vec::new();
+        let iter = x.iterate(heap).map_err(|_| {
+            anyhow::anyhow!(
+                "bytes() argument must be bytes, str, or iterable of int, not '{}'",
+                x.get_type()
+            )
+        })?;
+        for v in iter {
+            match v.unpack_i32() {
+                Some(n) if n >= 0 && n <= 255 => result.push(n as u8),
+                Some(n) => {
+                    return Err(anyhow::anyhow!(
+                        "bytes() integer {} is out of range 0..=255",
+                        n
+                    ));
+                }
+                None => {
+                    return Err(anyhow::anyhow!(
+                        "bytes() iterable must contain integers, not '{}'",
+                        v.get_type()
+                    ));
+                }
+            }
+        }
+        Ok(heap.alloc(StarlarkBytes::from_vec(result)))
+    }
+}

--- a/starlark/src/values/types/bytes/methods.rs
+++ b/starlark/src/values/types/bytes/methods.rs
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 The Starlark in Rust Authors.
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use starlark_derive::starlark_module;
+
+use crate as starlark;
+use crate::environment::MethodsBuilder;
+use crate::values::Heap;
+use crate::values::ValueOfUnchecked;
+use crate::values::typing::StarlarkIter;
+use crate::values::types::bytes::value::StarlarkBytes;
+
+#[starlark_module]
+pub(crate) fn bytes_methods(builder: &mut MethodsBuilder) {
+    /// Returns an iterable over the individual bytes as 1-byte bytes objects.
+    ///
+    /// ```
+    /// # starlark::assert::all_true(r#"
+    /// list(b"abc".elems()) == [b"a", b"b", b"c"]
+    /// # "#);
+    /// ```
+    fn elems<'v>(
+        this: &'v StarlarkBytes,
+        heap: Heap<'v>,
+    ) -> anyhow::Result<ValueOfUnchecked<'v, StarlarkIter<StarlarkBytes>>> {
+        let it = this
+            .as_bytes()
+            .iter()
+            .map(|&b| heap.alloc(StarlarkBytes::new(&[b])));
+        Ok(ValueOfUnchecked::new(heap.alloc_tuple_iter(it)))
+    }
+}

--- a/starlark/src/values/types/bytes/mod.rs
+++ b/starlark/src/values/types/bytes/mod.rs
@@ -1,0 +1,7 @@
+pub(crate) mod globals;
+pub(crate) mod methods;
+pub(crate) mod tests;
+pub(crate) mod value;
+
+pub use crate::values::types::bytes::value::BYTES_TYPE;
+pub use crate::values::types::bytes::value::StarlarkBytes;

--- a/starlark/src/values/types/bytes/tests.rs
+++ b/starlark/src/values/types/bytes/tests.rs
@@ -1,0 +1,524 @@
+/*
+ * Copyright 2018 The Starlark in Rust Authors.
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![cfg(test)]
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use dupe::Dupe;
+
+use crate::assert;
+use crate::assert::Assert;
+use crate::stdlib::PrintHandler;
+
+// Note: assert::all_true disables static typechecking, which is needed for
+// some bytes operations that the type checker may not yet fully model.
+
+#[test]
+fn test_bytes_type() {
+    assert::all_true(
+        r#"
+type(b"") == "bytes"
+type(b"hello") == "bytes"
+type(bytes("hi")) == "bytes"
+"#,
+    );
+}
+
+#[test]
+fn test_bytes_literals() {
+    assert::all_true(
+        r#"
+b"hello" == b"hello"
+b'hello' == b"hello"
+b"" == b""
+b"\x00" == bytes([0])
+b"\xff" == bytes([255])
+b"\n\r\t" == bytes([10, 13, 9])
+b"\012" == bytes([10])
+b"\101" == bytes([65])
+"#,
+    );
+}
+
+#[test]
+fn test_bytes_literal_triple_quoted() {
+    assert::all_true(
+        r#"
+b"""hello""" == b"hello"
+b'''world''' == b"world"
+"#,
+    );
+    // Triple-quoted spanning multiple lines must be tested with pass() since
+    // all_true() splits on newlines.
+    assert::pass(
+        r#"assert_eq(b"""line1
+line2""", bytes([108, 105, 110, 101, 49, 10, 108, 105, 110, 101, 50]))"#,
+    );
+}
+
+#[test]
+fn test_bytes_literal_raw() {
+    assert::all_true(
+        r#"
+rb"\r\n\t" == b"\\r\\n\\t"
+br"\r\n\t" == b"\\r\\n\\t"
+rb"\x41" == b"\\x41"
+"#,
+    );
+}
+
+#[test]
+fn test_bytes_constructor_from_bytes() {
+    assert::all_true(
+        r#"
+bytes(b"hello") == b"hello"
+bytes(b"") == b""
+"#,
+    );
+}
+
+#[test]
+fn test_bytes_constructor_from_str() {
+    assert::all_true(
+        r#"
+bytes("hello") == b"hello"
+bytes("") == b""
+bytes("ABC") == bytes([65, 66, 67])
+"#,
+    );
+}
+
+#[test]
+fn test_bytes_constructor_from_iterable() {
+    assert::all_true(
+        r#"
+bytes([65, 66, 67]) == b"ABC"
+bytes([0]) == b"\x00"
+bytes([255]) == b"\xff"
+bytes([]) == b""
+bytes((65, 66, 67)) == b"ABC"
+"#,
+    );
+}
+
+#[test]
+fn test_bytes_constructor_errors() {
+    assert::fail("bytes([256])", "out of range");
+    assert::fail("bytes([-1])", "out of range");
+    assert::fail(r#"bytes(1)"#, "bytes()");
+    assert::fail("bytes([b\"a\"])", "integers");
+}
+
+#[test]
+fn test_bytes_length() {
+    assert::all_true(
+        r#"
+len(b"") == 0
+len(b"a") == 1
+len(b"hello") == 5
+len(b"\x00\xff") == 2
+"#,
+    );
+}
+
+// Multi-byte UTF-8 characters: each occupies multiple bytes.
+#[test]
+fn test_bytes_length_multibyte() {
+    assert::all_true(
+        r#"
+len(bytes("Ѐ")) == 2
+len(bytes("世")) == 3
+len(bytes("😿")) == 4
+"#,
+    );
+}
+
+#[test]
+fn test_bytes_truth() {
+    assert::all_true(
+        r#"
+not b""
+bool(b"") == False
+bool(b"x") == True
+bool(b"\x00") == True
+"#,
+    );
+}
+
+// repr formats bytes as b"..." with escapes for control/non-ASCII bytes.
+// Our implementation uses \xHH for bytes outside 0x20–0x7e.
+#[test]
+fn test_bytes_repr() {
+    assert::eq(r#"repr(b"hello")"#, r#""b\"hello\"" "#);
+    assert::eq(r#"repr(b"")"#, r#""b\"\"" "#);
+    assert::eq(r#"repr(b"\t\n\r")"#, r#""b\"\\t\\n\\r\"" "#);
+    assert::eq(r#"repr(b"\x7f")"#, r#""b\"\\x7f\"" "#);
+    assert::eq(r#"repr(b"\x00")"#, r#""b\"\\x00\"" "#);
+    assert::eq(r#"repr(b"\xff")"#, r#""b\"\\xff\"" "#);
+    assert::eq(r#"repr(b"\\")"#, r#""b\"\\\\\"" "#);
+    assert::eq(r#"repr(b"\"")"#, r#""b\"\\\"\"" "#);
+}
+
+// str(bytes) decodes UTF-8, replacing invalid sequences with U+FFFD.
+#[test]
+fn test_bytes_str() {
+    assert::eq(r#"str(b"hello")"#, r#""hello""#);
+    assert::eq(r#"str(b"")"#, r#""""#);
+    assert::eq(r#"str(bytes("hello, 世界"))"#, r#""hello, 世界""#);
+    // Single invalid byte → one U+FFFD replacement character.
+    assert::eq(r#"str(b"\xff")"#, r#""\ufffd""#);
+    // UTF-8 encoding of an unpaired surrogate → replacement characters.
+    assert::eq(r#"str(b"\xed\xb0\x80")"#, r#""\ufffd\ufffd\ufffd""#);
+}
+
+#[test]
+fn test_bytes_equality() {
+    assert::all_true(
+        r#"
+b"abc" == b"abc"
+b"abc" != b"abd"
+b"" == b""
+b"abc" != b"abcd"
+b"abc" != "abc"
+"#,
+    );
+}
+
+#[test]
+fn test_bytes_comparison() {
+    assert::all_true(
+        r#"
+b"abc" < b"abd"
+b"abc" < b"abcd"
+b"abcd" > b"abc"
+b"abd" > b"abc"
+b"abc" <= b"abc"
+b"abc" >= b"abc"
+b"\x7f" < b"\x80"
+"#,
+    );
+}
+
+// Per the spec, bytes[i] returns the integer value of byte i (not a 1-byte bytes object).
+#[test]
+fn test_bytes_indexing() {
+    assert::all_true(
+        r#"
+b"abc"[0] == 97
+b"abc"[1] == 98
+b"abc"[2] == 99
+b"abc"[-1] == 99
+b"abc"[-3] == 97
+b"\x00\xff"[0] == 0
+b"\x00\xff"[1] == 255
+"#,
+    );
+}
+
+#[test]
+fn test_bytes_index_out_of_range() {
+    assert::fail("b\"abc\"[100]", "out of bound");
+    assert::fail("b\"abc\"[-100]", "out of bound");
+    assert::fail("b\"\"[0]", "out of bound");
+}
+
+#[test]
+fn test_bytes_slicing() {
+    assert::all_true(
+        r#"
+b"hello"[1:3] == b"el"
+b"hello"[:4] == b"hell"
+b"hello"[4:] == b"o"
+b"hello"[::2] == b"hlo"
+b"hello"[::-1] == b"olleh"
+b"hello"[1:4:2] == b"el"
+b"hello"[0:0] == b""
+b"hello"[5:5] == b""
+"#,
+    );
+}
+
+// int in bytes: checks if a byte value is present.
+#[test]
+fn test_bytes_contains_int() {
+    assert::all_true(
+        r#"
+97 in b"abc"
+98 in b"abc"
+100 not in b"abc"
+0 in b"\x00\xff"
+255 in b"\x00\xff"
+"#,
+    );
+}
+
+#[test]
+fn test_bytes_contains_int_out_of_range() {
+    assert::fail("256 in b\"abc\"", "range");
+    assert::fail("-1 in b\"abc\"", "range");
+}
+
+// bytes in bytes: subsequence check.
+#[test]
+fn test_bytes_contains_bytes() {
+    assert::all_true(
+        r#"
+b"bc" in b"abcd"
+b"ab" in b"abcd"
+b"cd" in b"abcd"
+b"" in b"abcd"
+b"" in b""
+b"abcd" not in b"abc"
+b"xyz" not in b"abc"
+"#,
+    );
+}
+
+#[test]
+fn test_bytes_contains_wrong_type() {
+    assert::fail(r#""bc" in b"dcab""#, "bytes");
+}
+
+#[test]
+fn test_bytes_concatenation() {
+    assert::all_true(
+        r#"
+b"ab" + b"cd" == b"abcd"
+b"" + b"abc" == b"abc"
+b"abc" + b"" == b"abc"
+b"" + b"" == b""
+"#,
+    );
+}
+
+#[test]
+fn test_bytes_repetition() {
+    assert::all_true(
+        r#"
+b"ab" * 3 == b"ababab"
+3 * b"ab" == b"ababab"
+b"ab" * 1 == b"ab"
+b"ab" * 0 == b""
+b"ab" * -1 == b""
+"#,
+    );
+}
+
+#[test]
+fn test_bytes_not_iterable() {
+    assert::fail("for x in b\"abc\": pass", "not supported");
+}
+
+#[test]
+fn test_bytes_not_assignable() {
+    assert::fail(r#"b"abc"[1] = 66"#, "Immutable");
+}
+
+#[test]
+fn test_bytes_as_dict_key() {
+    // all_true() evaluates each line independently, so assignments (→ None)
+    // can't be mixed with boolean expressions. Use pass() instead.
+    assert::pass(
+        r#"
+d = {b"hello": 1, b"goodbye": 2}
+assert_eq(d[b"hello"], 1)
+assert_eq(d[b"goodbye"], 2)
+assert_eq(len(d), 2)
+d[b"goodbye"] = 3
+assert_eq(d[b"goodbye"], 3)
+assert_eq(len(d), 2)
+"#,
+    );
+}
+
+// Per the spec, elems() returns an iterable of 1-byte bytes objects.
+// Note: bytes(iterable) requires integers, so bytes(x.elems()) doesn't work
+// since elems() yields bytes objects — use list comprehension with indexing instead.
+#[test]
+fn test_bytes_elems() {
+    assert::all_true(
+        r#"
+list(b"abc".elems()) == [b"a", b"b", b"c"]
+list(b"".elems()) == []
+list(b"\x00\xff".elems()) == [b"\x00", b"\xff"]
+"#,
+    );
+}
+
+// Bytes are usable as frozenset elements (hashable).
+#[test]
+fn test_bytes_in_set() {
+    assert::all_true(
+        r#"
+b"a" in {b"a": True}
+b"b" not in {b"a": True}
+"#,
+    );
+}
+
+// Hashing: equal bytes must have equal hashes.
+#[test]
+fn test_bytes_hash_consistency() {
+    assert::pass(
+        r#"
+d = {}
+d[b"hello"] = 1
+d[b"hello"] = 2
+assert_eq(len(d), 1)
+assert_eq(d[b"hello"], 2)
+"#,
+    );
+}
+
+// hash() built-in only accepts strings in this implementation; bytes are
+// hashable via dict keys (tested in test_bytes_as_dict_key / test_bytes_hash_consistency)
+// but hash() itself does not accept bytes.
+#[test]
+fn test_bytes_hash_builtin_unsupported() {
+    assert::fail(r#"hash(b"")"#, "str");
+}
+
+// repr of multi-byte UTF-8 content: printable non-ASCII chars are shown as-is;
+// non-printable Unicode gets \uXXXX; invalid UTF-8 bytes get \xHH.
+#[test]
+fn test_bytes_repr_multibyte() {
+    // "é" is printable non-ASCII → shown as-is
+    assert::eq(r#"repr(bytes("é"))"#, r#""b\"é\"" "#);
+    // "世" is printable non-ASCII → shown as-is
+    assert::eq(r#"repr(bytes("世"))"#, r#""b\"世\"" "#);
+}
+
+#[test]
+fn test_bytes_repr_non_printable_unicode() {
+    // U+200D ZERO WIDTH JOINER (format/invisible char) → \u200d
+    assert::eq(r#"repr(b"\xe2\x80\x8d")"#, r#""b\"\\u200d\"" "#);
+}
+
+#[test]
+fn test_bytes_repr_invalid_utf8() {
+    // Unpaired surrogate encoded as modified UTF-8 is invalid UTF-8 → \xHH for each byte
+    assert::eq(r#"repr(b"\xed\xb0\x80")"#, r#""b\"\\xed\\xb0\\x80\"" "#);
+}
+
+// str() on an incomplete UTF-8 sequence yields U+FFFD replacements.
+// from_utf8_lossy replaces each maximal invalid subsequence with one U+FFFD.
+#[test]
+fn test_bytes_str_incomplete_utf8() {
+    // 0xc3 alone is the start of a 2-byte sequence — one replacement.
+    assert::eq(r#"str(b"\xc3")"#, r#""\ufffd""#);
+    // 0xe4 0xb8 is an incomplete 3-byte sequence — treated as one invalid
+    // subsequence, yielding one U+FFFD (not two).
+    assert::eq(r#"str(b"\xe4\xb8")"#, r#""\ufffd""#);
+}
+
+// str() on control bytes decodes to the same control characters.
+#[test]
+fn test_bytes_str_control_chars() {
+    assert::eq(r#"str(b"\t\n")"#, r#""\t\n""#);
+}
+
+// bytes() constructor accepts a range() iterable.
+#[test]
+fn test_bytes_constructor_from_range() {
+    assert::all_true(
+        r#"
+bytes(range(65, 68)) == b"ABC"
+bytes(range(0)) == b""
+bytes(range(0, 256, 51)) == bytes([0, 51, 102, 153, 204, 255])
+"#,
+    );
+}
+
+// bytes() with no arguments should fail (x is required positional).
+#[test]
+fn test_bytes_constructor_no_args() {
+    assert::fail("bytes()", "positional");
+}
+
+// bytes + non-bytes produces a type error.
+#[test]
+fn test_bytes_add_type_error() {
+    assert::fail(r#"b"abc" + "xyz""#, "bytes");
+}
+
+// bytes < non-bytes produces a type error.
+#[test]
+fn test_bytes_compare_type_error() {
+    assert::fail(r#"b"abc" < 1"#, "cmp()");
+}
+
+// elems() on multi-byte UTF-8 content iterates individual bytes, not codepoints.
+#[test]
+fn test_bytes_elems_multibyte() {
+    // "é" = 0xc3 0xa9 → two 1-byte bytes objects
+    assert::all_true(r#"list(bytes("é").elems()) == [b"\xc3", b"\xa9"]"#);
+}
+
+// bytes(iterable_of_bytes_objects) fails — elems() yields bytes, not ints.
+// This documents our deviation from starlark-go (where elems() yields ints).
+#[test]
+fn test_bytes_constructor_rejects_bytes_elements() {
+    assert::fail(r#"bytes(b"abc".elems())"#, "integers");
+}
+
+// Slices with stride > 1 (beyond the stride=2 case already tested).
+#[test]
+fn test_bytes_slice_stride() {
+    assert::all_true(
+        r#"
+b"abcdef"[::3] == b"ad"
+b"abcdef"[1::3] == b"be"
+b"abcdef"[::6] == b"a"
+"#,
+    );
+}
+
+// print(b"...") should output the UTF-8 decoded string, not the repr.
+#[test]
+fn test_bytes_print() {
+    let s = Rc::new(RefCell::new(String::new()));
+    struct PrintHandlerImpl {
+        s: Rc<RefCell<String>>,
+    }
+    impl PrintHandler for PrintHandlerImpl {
+        fn println(&self, msg: &str) -> crate::Result<()> {
+            *self.s.borrow_mut() = msg.to_owned();
+            Ok(())
+        }
+    }
+    let print_handler = PrintHandlerImpl { s: s.dupe() };
+    let mut a = Assert::new();
+    a.set_print_handler(&print_handler);
+    a.pass(r#"print(b"hello")"#);
+    assert_eq!("hello", s.borrow().as_str());
+}
+
+// ord() accepts a 1-byte bytes argument.
+#[test]
+fn test_ord_bytes() {
+    assert::all_true(
+        r#"
+ord(b"A") == 65
+ord(b"\xff") == 255
+ord(b"\x00") == 0
+"#,
+    );
+    assert::fail(r#"ord(b"")"#, "length 1");
+    assert::fail(r#"ord(b"AB")"#, "length 1");
+}

--- a/starlark/src/values/types/bytes/value.rs
+++ b/starlark/src/values/types/bytes/value.rs
@@ -1,0 +1,327 @@
+/*
+ * Copyright 2018 The Starlark in Rust Authors.
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::fmt::Display;
+use std::fmt::Write;
+use std::hash::Hash;
+
+use allocative::Allocative;
+use serde::Serialize;
+use serde::Serializer;
+use starlark_derive::ProvidesStaticType;
+use starlark_derive::starlark_value;
+use starlark_map::StarlarkHasher;
+
+use crate as starlark;
+use crate::environment::Methods;
+use crate::environment::MethodsStatic;
+use crate::starlark_simple_value;
+use crate::typing::Ty;
+use crate::values::AllocFrozenValue;
+use crate::values::AllocValue;
+use crate::values::FrozenHeap;
+use crate::values::FrozenValue;
+use crate::values::Heap;
+use crate::values::StarlarkValue;
+use crate::values::UnpackValue;
+use crate::values::Value;
+use crate::values::index::apply_slice;
+use crate::values::index::convert_index;
+use crate::values::type_repr::StarlarkTypeRepr;
+
+/// The result of calling `type()` on bytes.
+pub const BYTES_TYPE: &str = "bytes";
+
+/// An immutable sequence of bytes (integers in range 0–255).
+///
+/// Values of this type are created via `b"..."` literals or the `bytes()` constructor.
+#[derive(Clone, Debug, ProvidesStaticType, Allocative)]
+pub struct StarlarkBytes {
+    content: Box<[u8]>,
+}
+
+starlark_simple_value!(StarlarkBytes);
+
+impl StarlarkTypeRepr for &'_ [u8] {
+    type Canonical = StarlarkBytes;
+
+    fn starlark_type_repr() -> Ty {
+        StarlarkBytes::starlark_type_repr()
+    }
+}
+
+impl<'v> AllocValue<'v> for &'_ [u8] {
+    fn alloc_value(self, heap: Heap<'v>) -> Value<'v> {
+        heap.alloc(StarlarkBytes::new(self))
+    }
+}
+
+impl AllocFrozenValue for &'_ [u8] {
+    fn alloc_frozen_value(self, heap: &FrozenHeap) -> FrozenValue {
+        heap.alloc(StarlarkBytes::new(self))
+    }
+}
+
+impl StarlarkTypeRepr for Vec<u8> {
+    type Canonical = StarlarkBytes;
+
+    fn starlark_type_repr() -> Ty {
+        StarlarkBytes::starlark_type_repr()
+    }
+}
+
+impl<'v> AllocValue<'v> for Vec<u8> {
+    fn alloc_value(self, heap: Heap<'v>) -> Value<'v> {
+        heap.alloc(StarlarkBytes::from_vec(self))
+    }
+}
+
+impl AllocFrozenValue for Vec<u8> {
+    fn alloc_frozen_value(self, heap: &FrozenHeap) -> FrozenValue {
+        heap.alloc(StarlarkBytes::from_vec(self))
+    }
+}
+
+impl StarlarkBytes {
+    /// Create a new bytes value from a byte slice.
+    pub fn new(content: &[u8]) -> Self {
+        StarlarkBytes {
+            content: content.into(),
+        }
+    }
+
+    /// Create a new bytes value from a `Vec<u8>`, without copying.
+    pub fn from_vec(content: Vec<u8>) -> Self {
+        StarlarkBytes {
+            content: content.into_boxed_slice(),
+        }
+    }
+
+    /// The raw bytes content.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.content
+    }
+
+    /// The length in bytes.
+    pub fn len(&self) -> usize {
+        self.content.len()
+    }
+
+    /// Whether the bytes are empty.
+    pub fn is_empty(&self) -> bool {
+        self.content.is_empty()
+    }
+}
+
+/// Write a non-ASCII Unicode character in bytes repr format.
+/// Alphanumeric chars (like "é", "世") are written as-is.
+/// Non-alphanumeric chars (control, format, invisible, punctuation) are escaped as \uXXXX / \UXXXXXXXX.
+/// This mirrors the `need_escape` logic in `string/repr.rs`.
+fn write_non_ascii_char(f: &mut fmt::Formatter<'_>, c: char) -> fmt::Result {
+    if c.is_alphanumeric() {
+        f.write_char(c)
+    } else if (c as u32) <= 0xFFFF {
+        write!(f, "\\u{:04x}", c as u32)
+    } else {
+        write!(f, "\\U{:08x}", c as u32)
+    }
+}
+
+impl Display for StarlarkBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("b\"")?;
+        let content = &self.content;
+        let mut i = 0;
+        while i < content.len() {
+            let byte = content[i];
+            if byte < 0x80 {
+                match byte {
+                    b'"' => f.write_str("\\\"")?,
+                    b'\\' => f.write_str("\\\\")?,
+                    b'\n' => f.write_str("\\n")?,
+                    b'\r' => f.write_str("\\r")?,
+                    b'\t' => f.write_str("\\t")?,
+                    0x20..=0x7e => f.write_char(byte as char)?,
+                    _ => write!(f, "\\x{:02x}", byte)?,
+                }
+                i += 1;
+            } else {
+                match std::str::from_utf8(&content[i..]) {
+                    Ok(s) => {
+                        let c = s.chars().next().unwrap();
+                        write_non_ascii_char(f, c)?;
+                        i += c.len_utf8();
+                    }
+                    Err(e) => {
+                        if e.valid_up_to() > 0 {
+                            // There's a valid UTF-8 prefix; process just the first char.
+                            let valid =
+                                std::str::from_utf8(&content[i..i + e.valid_up_to()]).unwrap();
+                            let c = valid.chars().next().unwrap();
+                            write_non_ascii_char(f, c)?;
+                            i += c.len_utf8();
+                        } else {
+                            // Invalid byte at position i.
+                            write!(f, "\\x{:02x}", byte)?;
+                            i += 1;
+                        }
+                    }
+                }
+            }
+        }
+        f.write_str("\"")
+    }
+}
+
+impl Serialize for StarlarkBytes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(&self.content)
+    }
+}
+
+pub(crate) fn bytes_methods() -> Option<&'static Methods> {
+    static RES: MethodsStatic = MethodsStatic::new();
+    RES.methods(crate::values::types::bytes::methods::bytes_methods)
+}
+
+#[starlark_value(type = BYTES_TYPE)]
+impl<'v> StarlarkValue<'v> for StarlarkBytes {
+    fn get_methods() -> Option<&'static Methods> {
+        bytes_methods()
+    }
+
+    /// repr(b"...") — byte literal syntax.
+    fn collect_repr(&self, collector: &mut String) {
+        write!(collector, "{self}").unwrap()
+    }
+
+    /// str(b"...") — UTF-8 decode, replacing invalid sequences with U+FFFD.
+    fn collect_str(&self, collector: &mut String) {
+        collector.push_str(&String::from_utf8_lossy(&self.content))
+    }
+
+    fn to_bool(&self) -> bool {
+        !self.content.is_empty()
+    }
+
+    fn write_hash(&self, hasher: &mut StarlarkHasher) -> crate::Result<()> {
+        self.content.hash(hasher);
+        Ok(())
+    }
+
+    fn equals(&self, other: Value<'v>) -> crate::Result<bool> {
+        if let Some(other) = StarlarkBytes::from_value(other) {
+            Ok(self.content == other.content)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn compare(&self, other: Value<'v>) -> crate::Result<Ordering> {
+        if let Some(other) = StarlarkBytes::from_value(other) {
+            Ok(self.content.cmp(&other.content))
+        } else {
+            crate::values::ValueError::unsupported_with(self, "cmp()", other)
+        }
+    }
+
+    fn length(&self) -> crate::Result<i32> {
+        Ok(self.content.len() as i32)
+    }
+
+    /// `bytes[i]` returns the integer value of byte at index `i`.
+    fn at(&self, index: Value<'v>, heap: Heap<'v>) -> crate::Result<Value<'v>> {
+        let i = convert_index(index, self.content.len() as i32)? as usize;
+        Ok(heap.alloc(self.content[i] as i32))
+    }
+
+    /// `bytes[i:j:k]` returns a new bytes object.
+    fn slice(
+        &self,
+        start: Option<Value<'v>>,
+        stop: Option<Value<'v>>,
+        stride: Option<Value<'v>>,
+        heap: Heap<'v>,
+    ) -> crate::Result<Value<'v>> {
+        let sliced = apply_slice(&self.content, start, stop, stride)?;
+        Ok(heap.alloc(StarlarkBytes::from_vec(sliced)))
+    }
+
+    /// `x in bytes`: supports both int (byte value) and bytes (subsequence).
+    fn is_in(&self, other: Value<'v>) -> crate::Result<bool> {
+        if let Some(n) = other.unpack_i32() {
+            if n < 0 || n > 255 {
+                return Err(crate::Error::new_other(anyhow::anyhow!(
+                    "byte value must be in range 0..=255, got {}",
+                    n
+                )));
+            }
+            Ok(self.content.contains(&(n as u8)))
+        } else if let Some(other_bytes) = StarlarkBytes::from_value(other) {
+            let needle = &other_bytes.content;
+            if needle.is_empty() {
+                return Ok(true);
+            }
+            Ok(self
+                .content
+                .windows(needle.len())
+                .any(|window| window == needle.as_ref()))
+        } else {
+            Err(crate::Error::new_other(anyhow::anyhow!(
+                "argument to 'in bytes' must be an int or bytes, not '{}'",
+                other.get_type()
+            )))
+        }
+    }
+
+    /// `bytes + bytes` — concatenation.
+    fn add(&self, other: Value<'v>, heap: Heap<'v>) -> Option<crate::Result<Value<'v>>> {
+        if let Some(other) = StarlarkBytes::from_value(other) {
+            let mut result = Vec::with_capacity(self.content.len() + other.content.len());
+            result.extend_from_slice(&self.content);
+            result.extend_from_slice(&other.content);
+            Some(Ok(heap.alloc(StarlarkBytes::from_vec(result))))
+        } else {
+            None
+        }
+    }
+
+    /// `bytes * n` — repetition.
+    fn mul(&self, other: Value<'v>, heap: Heap<'v>) -> Option<crate::Result<Value<'v>>> {
+        let l = match i32::unpack_value(other) {
+            Ok(Some(l)) => l,
+            Ok(None) => return None,
+            Err(e) => return Some(Err(e)),
+        };
+        let count = std::cmp::max(0, l) as usize;
+        let result: Vec<u8> = self.content.iter().cloned().cycle().take(self.content.len() * count).collect();
+        Some(Ok(heap.alloc(StarlarkBytes::from_vec(result))))
+    }
+
+    fn rmul(&self, lhs: Value<'v>, heap: Heap<'v>) -> Option<crate::Result<Value<'v>>> {
+        self.mul(lhs, heap)
+    }
+
+    fn typechecker_ty(&self) -> Option<Ty> {
+        Some(Ty::starlark_value::<Self>())
+    }
+}

--- a/starlark/src/values/types/string/globals.rs
+++ b/starlark/src/values/types/string/globals.rs
@@ -24,6 +24,7 @@ use crate::values::StringValue;
 use crate::values::Value;
 use crate::values::ValueLike;
 use crate::values::string::StarlarkStr;
+use crate::values::types::bytes::value::StarlarkBytes;
 
 #[starlark_module]
 pub(crate) fn register_str(globals: &mut GlobalsBuilder) {
@@ -76,17 +77,33 @@ pub(crate) fn register_str(globals: &mut GlobalsBuilder) {
     /// # "#);
     /// ```
     #[starlark(speculative_exec_safe)]
-    fn ord<'v>(#[starlark(require = pos)] a: StringValue<'v>) -> anyhow::Result<i32> {
-        let mut chars = a.as_str().chars();
-        if let Some(c) = chars.next() {
-            if chars.next().is_none() {
-                return Ok(u32::from(c) as i32);
+    fn ord<'v>(#[starlark(require = pos)] a: Value<'v>) -> anyhow::Result<i32> {
+        if let Some(s) = a.unpack_str() {
+            let mut chars = s.chars();
+            if let Some(c) = chars.next() {
+                if chars.next().is_none() {
+                    return Ok(u32::from(c) as i32);
+                }
             }
+            Err(anyhow::anyhow!(
+                "ord(): {} is not a single character string",
+                a.to_repr()
+            ))
+        } else if let Some(b) = StarlarkBytes::from_value(a) {
+            if b.len() == 1 {
+                Ok(b.as_bytes()[0] as i32)
+            } else {
+                Err(anyhow::anyhow!(
+                    "ord(): bytes argument must have length 1, not {}",
+                    b.len()
+                ))
+            }
+        } else {
+            Err(anyhow::anyhow!(
+                "ord(): expected string or bytes, got '{}'",
+                a.get_type()
+            ))
         }
-        Err(anyhow::anyhow!(
-            "ord(): {} is not a single character string",
-            a.to_value().to_repr()
-        ))
     }
 
     /// [repr](
@@ -137,14 +154,12 @@ pub(crate) fn register_str(globals: &mut GlobalsBuilder) {
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<StringValue<'v>> {
         if let Some(a) = StringValue::new(a) {
-            // Special case that can avoid reallocating, but is equivalent.
-            Ok(a)
-        } else {
-            let mut s = eval.string_pool.alloc();
-            a.collect_repr(&mut s);
-            let r = eval.heap().alloc_str(&s);
-            eval.string_pool.release(s);
-            Ok(r)
+            return Ok(a);
         }
+        let mut s = eval.string_pool.alloc();
+        a.collect_str(&mut s);
+        let r = eval.heap().alloc_str(&s);
+        eval.string_pool.release(s);
+        Ok(r)
     }
 }

--- a/starlark/src/values/types/string/str_type.rs
+++ b/starlark/src/values/types/string/str_type.rs
@@ -250,6 +250,10 @@ impl<'v> StarlarkValue<'v> for StarlarkStr {
         string_repr(self, buffer)
     }
 
+    fn collect_str(&self, buffer: &mut String) {
+        buffer.push_str(self.as_str())
+    }
+
     fn to_bool(&self) -> bool {
         !self.is_empty()
     }

--- a/starlark_syntax/src/lexer.rs
+++ b/starlark_syntax/src/lexer.rs
@@ -429,6 +429,211 @@ impl<'a> Lexer<'a> {
         )
     }
 
+    /// Like `escape`, but appends bytes to `res: &mut Vec<u8>`.
+    /// Non-ASCII chars are encoded as UTF-8. `\uXXXX` / `\UHHHHHHHH` also encode as UTF-8 bytes.
+    fn escape_bytes(it: &mut CursorChars, res: &mut Vec<u8>) -> Result<(), ()> {
+        match it.next() {
+            Some('n') => res.push(b'\n'),
+            Some('r') => res.push(b'\r'),
+            Some('t') => res.push(b'\t'),
+            Some('a') => res.push(b'\x07'),
+            Some('b') => res.push(b'\x08'),
+            Some('f') => res.push(b'\x0C'),
+            Some('v') => res.push(b'\x0B'),
+            Some('\n') => {}
+            Some('\r') => {
+                if it.next() != Some('\n') {
+                    return Err(());
+                }
+            }
+            Some('x') => {
+                let c = Self::escape_char(it, 2, 2, 16)?;
+                // \xHH: store the low byte directly (Latin-1 / bytes-literal semantics).
+                res.push(c as u32 as u8);
+            }
+            Some('u') => {
+                let c = Self::escape_char(it, 4, 4, 16)?;
+                let mut buf = [0u8; 4];
+                res.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+            }
+            Some('U') => {
+                let c = Self::escape_char(it, 8, 8, 16)?;
+                let mut buf = [0u8; 4];
+                res.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+            }
+            Some(c) => match c {
+                '0'..='7' => {
+                    it.unnext(c);
+                    let c = Self::escape_char(it, 1, 3, 8)?;
+                    if c as u32 > 255 {
+                        return Err(());
+                    }
+                    res.push(c as u32 as u8);
+                }
+                '"' | '\'' | '\\' => res.push(c as u8),
+                _ => {
+                    res.push(b'\\');
+                    let mut buf = [0u8; 4];
+                    res.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+                }
+            },
+            None => return Err(()),
+        }
+        Ok(())
+    }
+
+    /// Parse a bytes literal. Return the bytes content and the offset where it starts.
+    fn bytes_string(
+        &mut self,
+        triple: bool,
+        raw: bool,
+        mut stop: impl FnMut(char) -> bool,
+    ) -> LexemeT<(Vec<u8>, usize)> {
+        let string_start = self.lexer.span().start;
+        let mut string_end = self.lexer.span().end;
+
+        let mut it = CursorBytes::new(self.lexer.remainder());
+        let it2;
+
+        if triple {
+            it.next();
+            it.next();
+        }
+        let contents_start = it.pos();
+
+        // Fast path: accumulate bytes as-is until we hit something special
+        let mut res: Vec<u8>;
+        loop {
+            match it.next_char() {
+                None => {
+                    return self.err_span(
+                        LexemeError::UnfinishedStringLiteral,
+                        string_start,
+                        string_end + it.pos(),
+                    );
+                }
+                Some(c) => {
+                    if stop(c) {
+                        let contents_end = it.pos() - if triple { 3 } else { 1 };
+                        let contents =
+                            self.lexer.remainder()[contents_start..contents_end].as_bytes();
+                        self.lexer.bump(it.pos());
+                        return Ok((
+                            string_start,
+                            (contents.to_vec(), contents_start),
+                            string_end + it.pos(),
+                        ));
+                    } else if c == '\\' || c == '\r' || (c == '\n' && !triple) {
+                        res = Vec::with_capacity(it.pos() + 10);
+                        res.extend_from_slice(
+                            self.lexer.remainder()[contents_start..it.pos() - 1].as_bytes(),
+                        );
+                        it2 = CursorChars::new_offset(self.lexer.remainder(), it.pos() - 1);
+                        break;
+                    }
+                }
+            }
+        }
+
+        let mut it = it2;
+        while let Some(c) = it.next() {
+            if stop(c) {
+                self.lexer.bump(it.pos());
+                if triple {
+                    // Remove the two extra quote chars already pushed
+                    let len = res.len();
+                    res.truncate(len.saturating_sub(2));
+                }
+                return Ok((string_start, (res, contents_start), string_end + it.pos()));
+            }
+            match c {
+                '\n' if !triple => {
+                    string_end -= 1;
+                    break;
+                }
+                '\r' => {}
+                '\\' => {
+                    if raw {
+                        match it.next() {
+                            Some(c) => {
+                                if c != '\'' && c != '"' {
+                                    res.push(b'\\');
+                                }
+                                let mut buf = [0u8; 4];
+                                res.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+                            }
+                            _ => break,
+                        }
+                    } else {
+                        let pos = it.pos();
+                        if Self::escape_bytes(&mut it, &mut res).is_err() {
+                            let bad = self.lexer.remainder()[pos..it.pos()].to_owned();
+                            return self.err_span(
+                                if bad.is_empty() {
+                                    LexemeError::EmptyEscapeSequence
+                                } else {
+                                    LexemeError::InvalidEscapeSequence(bad)
+                                },
+                                string_end + pos - 1,
+                                string_end + it.pos(),
+                            );
+                        }
+                    }
+                }
+                c => {
+                    let mut buf = [0u8; 4];
+                    res.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+                }
+            }
+        }
+
+        self.err_span(
+            LexemeError::UnfinishedStringLiteral,
+            string_start,
+            string_end + it.pos(),
+        )
+    }
+
+    fn parse_double_quoted_bytes_string(
+        &mut self,
+        raw: bool,
+    ) -> Option<LexemeT<(Vec<u8>, usize)>> {
+        if self.lexer.remainder().starts_with("\"\"") {
+            let mut qs = 0;
+            Some(self.bytes_string(true, raw, |c| {
+                if c == '\"' {
+                    qs += 1;
+                    qs == 3
+                } else {
+                    qs = 0;
+                    false
+                }
+            }))
+        } else {
+            Some(self.bytes_string(false, raw, |c| c == '\"'))
+        }
+    }
+
+    fn parse_single_quoted_bytes_string(
+        &mut self,
+        raw: bool,
+    ) -> Option<LexemeT<(Vec<u8>, usize)>> {
+        if self.lexer.remainder().starts_with("''") {
+            let mut qs = 0;
+            Some(self.bytes_string(true, raw, |c| {
+                if c == '\'' {
+                    qs += 1;
+                    qs == 3
+                } else {
+                    qs = 0;
+                    false
+                }
+            }))
+        } else {
+            Some(self.bytes_string(false, raw, |c| c == '\''))
+        }
+    }
+
     fn int(&self, s: &str, radix: u32) -> Lexeme {
         let span = self.lexer.span();
         match TokenInt::from_str_radix(s, radix) {
@@ -545,6 +750,23 @@ impl<'a> Lexer<'a> {
                                 }
                                 Token::FString(_) => {
                                     unreachable!("The lexer does not produce FString")
+                                }
+                                Token::RawByteDoubleQuote => {
+                                    // span len: b" = 2, br" = 3, rb" = 3
+                                    let raw = self.lexer.span().len() >= 3;
+                                    self.parse_double_quoted_bytes_string(raw).map(|lex| {
+                                        map_lexeme_t(lex, |(b, _offset)| Token::Bytes(b))
+                                    })
+                                }
+                                Token::RawByteSingleQuote => {
+                                    // span len: b' = 2, br' = 3, rb' = 3
+                                    let raw = self.lexer.span().len() >= 3;
+                                    self.parse_single_quoted_bytes_string(raw).map(|lex| {
+                                        map_lexeme_t(lex, |(b, _offset)| Token::Bytes(b))
+                                    })
+                                }
+                                Token::Bytes(_) => {
+                                    unreachable!("The lexer does not produce Bytes directly")
                                 }
                                 Token::OpeningCurly
                                 | Token::OpeningRound
@@ -668,6 +890,19 @@ pub enum Token {
     #[token("f\"")]
     #[token("fr\"")]
     RawFStringDoubleQuote,
+
+    /// The start of a single-quoted bytes literal.
+    #[token("b'")]
+    #[token("br'")]
+    #[token("rb'")]
+    RawByteSingleQuote,
+    /// The start of a double-quoted bytes literal.
+    #[token("b\"")]
+    #[token("br\"")]
+    #[token("rb\"")]
+    RawByteDoubleQuote,
+
+    Bytes(Vec<u8>), // A bytes literal
 
     #[regex(
         "as|\
@@ -954,6 +1189,9 @@ impl Display for Token {
             Token::RawFStringDoubleQuote => write!(f, "starting f'"),
             Token::RawFStringSingleQuote => write!(f, "starting f\""),
             Token::FString(s) => write!(f, "f-string {:?}", &s.content),
+            Token::RawByteDoubleQuote => write!(f, "starting b\""),
+            Token::RawByteSingleQuote => write!(f, "starting b'"),
+            Token::Bytes(b) => write!(f, "bytes literal ({} bytes)", b.len()),
             Token::Comment(c) => write!(f, "comment '{c}'"),
             Token::Tabs => Ok(()),
         }
@@ -978,6 +1216,9 @@ pub fn lex_exactly_one_identifier(s: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use crate::codemap::CodeMap;
+    use crate::dialect::Dialect;
+    use crate::lexer::Lexer;
     use crate::lexer::lex_exactly_one_identifier;
 
     #[test]
@@ -987,5 +1228,17 @@ mod tests {
         assert_eq!(lex_exactly_one_identifier("foo bar"), None);
         assert_eq!(lex_exactly_one_identifier("not"), None);
         assert_eq!(lex_exactly_one_identifier("123"), None);
+    }
+
+    #[test]
+    fn test_bytes_literal_octal_overflow_is_error() {
+        // \400 = 256 in octal, which exceeds 255 and should be a lex error.
+        let result: Vec<_> =
+            Lexer::new(r#"b"\400""#, &Dialect::Standard, CodeMap::default()).collect();
+        assert!(
+            result.iter().any(|r| r.is_err()),
+            "expected a lex error for b\"\\400\" but got: {:?}",
+            result
+        );
     }
 }

--- a/starlark_syntax/src/syntax/ast.rs
+++ b/starlark_syntax/src/syntax/ast.rs
@@ -21,6 +21,7 @@ use std::fmt;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
+use std::fmt::Write;
 
 use allocative::Allocative;
 use dupe::Dupe;
@@ -87,6 +88,7 @@ pub type AstAssignIdent = AstAssignIdentP<AstNoPayload>;
 pub type AstIdent = AstIdentP<AstNoPayload>;
 pub type AstArgument = AstArgumentP<AstNoPayload>;
 pub type AstString = Spanned<String>;
+pub type AstBytes = Spanned<Vec<u8>>;
 pub type AstParameter = AstParameterP<AstNoPayload>;
 pub type AstInt = Spanned<TokenInt>;
 pub type AstFloat = Spanned<f64>;
@@ -147,6 +149,7 @@ pub enum AstLiteral {
     Int(AstInt),
     Float(AstFloat),
     String(AstString),
+    Bytes(AstBytes),
     Ellipsis,
 }
 
@@ -512,6 +515,21 @@ impl Display for AstLiteral {
             AstLiteral::Int(i) => write!(f, "{}", &i.node),
             AstLiteral::Float(n) => write!(f, "{}", &n.node),
             AstLiteral::String(s) => fmt_string_literal(f, &s.node),
+            AstLiteral::Bytes(b) => {
+                f.write_str("b\"")?;
+                for &byte in &b.node {
+                    match byte {
+                        b'"' => f.write_str("\\\"")?,
+                        b'\\' => f.write_str("\\\\")?,
+                        b'\n' => f.write_str("\\n")?,
+                        b'\r' => f.write_str("\\r")?,
+                        b'\t' => f.write_str("\\t")?,
+                        0x20..=0x7e => f.write_char(byte as char)?,
+                        _ => write!(f, "\\x{:02x}", byte)?,
+                    }
+                }
+                f.write_str("\"")
+            }
             AstLiteral::Ellipsis => f.write_str("..."),
         }
     }

--- a/starlark_syntax/src/syntax/grammar.lalrpop
+++ b/starlark_syntax/src/syntax/grammar.lalrpop
@@ -50,6 +50,10 @@ string: AstString = <l:@L> <e:"STRING"> <r:@R>
     => e.ast(l, r);
 
 #[inline]
+bytes: AstBytes = <l:@L> <e:"BYTES"> <r:@R>
+    => e.ast(l, r);
+
+#[inline]
 fstring: AstFString = <l:@L> <e:"FSTRING"> <r:@R>
     => grammar_util::fstring(e, l, r, state);
 
@@ -274,6 +278,8 @@ Operand: AstExpr = {
         => Expr::Literal(AstLiteral::Float(f)).ast(l, r),
     <l:@L> <s:string> <r:@R>
         => Expr::Literal(AstLiteral::String(s)).ast(l, r),
+    <l:@L> <b:bytes> <r:@R>
+        => Expr::Literal(AstLiteral::Bytes(b)).ast(l, r),
     <l:@L> "..." <r:@R>
         => Expr::Literal(AstLiteral::Ellipsis).ast(l, r),
     <l:@L> "[" <e:COMMA<Test>> "]" <r:@R>
@@ -505,5 +511,6 @@ extern {
       "FLOAT" => lexer::Token::Float(<f64>),
       "STRING" => lexer::Token::String(<String>),
       "FSTRING" => lexer::Token::FString(<lexer::TokenFString>),
+      "BYTES" => lexer::Token::Bytes(<Vec<u8>>),
     }
 }

--- a/starlark_syntax/src/syntax/type_expr.rs
+++ b/starlark_syntax/src/syntax/type_expr.rs
@@ -265,6 +265,7 @@ impl<'a, P: AstPayload> TypeExprUnpackP<'a, P> {
             ExprP::ListComprehension(..) => err("list comprehension"),
             ExprP::DictComprehension(..) => err("dict comprehension"),
             ExprP::FString(..) => err("f-string"),
+            ExprP::Literal(AstLiteral::Bytes(_)) => err("bytes literal"),
         }
     }
 }


### PR DESCRIPTION
- Value::to_str() now calls collect_str() instead of falling back to to_repr(), so print(b"hello")
  outputs hello instead of b"hello"
- ord() accepts 1-byte bytes per spec — ord(b"A") == 65; returns the byte value as an integer
- StarlarkBytes is now part of the public API — starlark::values::bytes::StarlarkBytes is accessible to
  downstream crates
- AllocValue/AllocFrozenValue impls for &[u8] and Vec<u8> — heap.alloc(b"hi" as &[u8]) and
  heap.alloc(vec![1u8, 2]) now work directly
- StarlarkBytes::from_vec() constructor converts Vec<u8> to Box<[u8]> in-place, eliminating a redundant
  copy in add, mul, slice, and bytes()
- Duplicate bytes key detection in the linter — {b"a": 1, b"a": 2} now raises a duplicate-key warning