### PR TITLE
feat: expose comments to parsing without changing API

### DIFF
--- a/starlark_syntax/src/syntax.rs
+++ b/starlark_syntax/src/syntax.rs
@@ -25,6 +25,7 @@ pub use crate::dialect::DialectTypes;
 
 pub mod ast;
 pub mod call;
+pub mod comments;
 pub mod def;
 #[cfg(test)]
 mod grammar_tests;

--- a/starlark_syntax/src/syntax/comments.rs
+++ b/starlark_syntax/src/syntax/comments.rs
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 The Starlark in Rust Authors.
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::codemap::Span;
+
+/// A comment found during parsing.
+#[derive(Debug, Clone)]
+pub struct Comment {
+    /// Span of the comment in the source, including the leading `#`.
+    pub span: Span,
+    /// The comment text, excluding the leading `#`.
+    pub text: String,
+}

--- a/starlark_syntax/src/syntax/module.rs
+++ b/starlark_syntax/src/syntax/module.rs
@@ -35,6 +35,7 @@ use crate::lexer::Lexer;
 use crate::lexer::Token;
 use crate::syntax::AstLoad;
 use crate::syntax::Dialect;
+use crate::syntax::comments::Comment;
 use crate::syntax::ast::ArgumentP;
 use crate::syntax::ast::AstExpr;
 use crate::syntax::ast::AstStmt;
@@ -126,6 +127,8 @@ pub struct AstModule {
     /// Lint issues suppressed in this module using inline comments of shape
     /// # starlark-lint-disable <ISSUE_NAME>, <ISSUE_NAME>, ...
     lint_suppressions: LintSuppressions,
+    /// All comments found in the source, in source order.
+    comments: Vec<Comment>,
 }
 
 /// This trait is not exported as public API of starlark.
@@ -164,6 +167,7 @@ impl AstModule {
         dialect: &Dialect,
         typecheck: bool,
         lint_suppressions: LintSuppressions,
+        comments: Vec<Comment>,
     ) -> crate::Result<AstModule> {
         let mut errors = Vec::new();
         validate_module(
@@ -184,6 +188,7 @@ impl AstModule {
             dialect: dialect.clone(),
             typecheck,
             lint_suppressions,
+            comments,
         })
     }
 
@@ -217,6 +222,8 @@ impl AstModule {
         let mut lint_suppressions_builder = LintSuppressionsBuilder::new();
         // Keep track of block of comments, used for accumulating lint suppressions
         let mut in_comment_block = false;
+        // Collect all comments in source order
+        let mut comments = Vec::new();
         let mut errors = Vec::new();
         match StarlarkParser::new().parse(
             &mut ParserState {
@@ -228,6 +235,10 @@ impl AstModule {
                 // Filter out comment tokens and accumulate lint suppressions
                 Ok((start, Token::Comment(comment), end)) => {
                     lint_suppressions_builder.parse_comment(&codemap, comment, *start, *end);
+                    comments.push(Comment {
+                        span: Span::new(Pos::new(*start as u32), Pos::new(*end as u32)),
+                        text: comment.clone(),
+                    });
                     in_comment_block = true;
                     false
                 }
@@ -250,6 +261,7 @@ impl AstModule {
                     dialect,
                     typecheck,
                     lint_suppressions_builder.build(),
+                    comments,
                 )?)
             }
             Err(p) => Err(parse_error_add_span(p, codemap.source().len(), &codemap)),
@@ -369,6 +381,12 @@ impl AstModule {
     pub fn is_suppressed(&self, issue_short_name: &str, issue_span: Span) -> bool {
         self.lint_suppressions
             .is_suppressed(issue_short_name, issue_span)
+    }
+
+    /// Returns all comments found in the source, in source order.
+    /// Each comment has a [`Span`] that can be resolved via [`file_span`](AstModule::file_span).
+    pub fn comments(&self) -> &[Comment] {
+        &self.comments
     }
 }
 


### PR DESCRIPTION
This should allow me to do things like merge BUILD.in comments for gazelle into the resulting BUILD, or other such things. It doesn't change the API so current usage is unaffected.