### PR TITLE
fix: guard ProfilerInstant against wasm32 Instant::now() panic

### DIFF
--- a/starlark/src/eval/runtime/profile/instant.rs
+++ b/starlark/src/eval/runtime/profile/instant.rs
@@ -20,24 +20,29 @@ use std::time::Duration;
 
 use allocative::Allocative;
 
-/// Real `Instant` for production code, thread-local counter for tests.
+/// Real `Instant` for production code, monotonic counter for tests and WASM.
+///
+/// On `wasm32-unknown-unknown`, `std::time::Instant` is not available
+/// (panics at runtime), so we use a thread-local counter instead.
+/// Profiling data won't reflect real wall-clock time on WASM, but the
+/// evaluator runs correctly.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Allocative)]
 pub(crate) struct ProfilerInstant(
-    #[cfg(not(test))] std::time::Instant,
-    #[cfg(test)] u64, // Millis.
+    #[cfg(not(any(test, target_arch = "wasm32")))] std::time::Instant,
+    #[cfg(any(test, target_arch = "wasm32"))] u64, // Millis.
 );
 
 impl ProfilerInstant {
-    #[cfg(test)]
+    #[cfg(any(test, target_arch = "wasm32"))]
     pub(crate) const TEST_TICK_MILLIS: u64 = 7;
 
     #[inline]
     pub(crate) fn now() -> Self {
-        #[cfg(not(test))]
+        #[cfg(not(any(test, target_arch = "wasm32")))]
         {
             ProfilerInstant(std::time::Instant::now())
         }
-        #[cfg(test)]
+        #[cfg(any(test, target_arch = "wasm32"))]
         {
             thread_local! {
                 static NOW_MILLIS: std::cell::Cell<u64> = const { std::cell::Cell::new(100003) };
@@ -52,11 +57,11 @@ impl ProfilerInstant {
 
     #[inline]
     pub(crate) fn duration_since(&self, earlier: ProfilerInstant) -> Duration {
-        #[cfg(not(test))]
+        #[cfg(not(any(test, target_arch = "wasm32")))]
         {
             self.0.duration_since(earlier.0)
         }
-        #[cfg(test)]
+        #[cfg(any(test, target_arch = "wasm32"))]
         {
             Duration::from_millis(self.0.checked_sub(earlier.0).unwrap())
         }
@@ -64,11 +69,11 @@ impl ProfilerInstant {
 
     #[inline]
     pub(crate) fn elapsed(&self) -> Duration {
-        #[cfg(not(test))]
+        #[cfg(not(any(test, target_arch = "wasm32")))]
         {
             self.0.elapsed()
         }
-        #[cfg(test)]
+        #[cfg(any(test, target_arch = "wasm32"))]
         {
             ProfilerInstant::now().duration_since(*self)
         }


### PR DESCRIPTION
## Summary

On `wasm32-unknown-unknown`, `std::time::Instant::now()` panics at runtime ("time not implemented on this platform"). `ProfilerInstant::now()` is called on every function enter/exit via `CallEnter`/`CallExit` heap markers, making the Starlark evaluator unusable on WASM.

This applies the same `#[cfg(any(test, target_arch = "wasm32"))]` guard pattern already used in `eval.rs` (line 68) and `modules.rs` (#154) — falling back to the existing monotonic thread-local counter. Profiling data won't reflect real wall-clock time on WASM, but the evaluator runs correctly.

## Context

We're compiling starlark-rust to WASM for a browser-based interactive policy tutorial. The evaluator, module system, and stdlib all work perfectly on `wasm32-unknown-unknown` — this was the last remaining `Instant::now()` call site that needed guarding.

## Changes

- `starlark/src/eval/runtime/profile/instant.rs`: Replace `#[cfg(not(test))]` / `#[cfg(test)]` with `#[cfg(not(any(test, target_arch = "wasm32")))]` / `#[cfg(any(test, target_arch = "wasm32"))]`