### PR TITLE
Add support for PEP 614-style decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This project features:
   values aren't.
 - [Garbage collected](docs/gc.md) values allocated on [a heap](docs/heaps.md).
 - Optional runtime-checked [types](docs/types.md).
+- Optional [decorators](docs/decorators.md).
 - A linter, to detect code issues in Starlark.
 - IDE integration in the form of
   [LSP](https://microsoft.github.io/language-server-protocol/).

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -1,0 +1,67 @@
+# Decorators
+
+The Starlark `decorators` extension enables [PEP 614](https://peps.python.org/pep-0614/)-style syntax.
+
+Basically, it enables code like this:
+
+```python
+@asdf
+def foo():
+    ...
+```
+
+... which is equivalent to this:
+
+```python
+def foo():
+    ...
+
+foo = asdf(foo)
+```
+
+All valid Starlark expressions (e.g. variables, calls, access via the dot operator, lambdas) work as decorator expressions.
+
+## Applying multiple decorators
+
+You can "stack" decorators:
+
+```python
+@dec1
+@dec2
+def foo():
+  ...
+```
+
+Since a decorator gets the result of the lines below as an argument, this is equivalent to:
+
+```python
+def foo():
+  ...
+  
+foo = dec1(dec2(foo))
+```
+
+So **the innermost/lowest decorator is applied first**, continuing outwards/up.
+
+## Relationship to typing
+
+Since [typing](./types.md) is limited in Starlark, compared to Python, it is currently not possible to preserve typing in the general case.
+An identity decorator in Python 3.12 and up can statically indicate that it preserves the typing of the function that it has been given:
+
+```python
+def identity[T, **P](f: Callable[P, T]) -> Callable[P, T]:
+    return f
+```
+
+Starlark does not support this syntax, so in these scenarios the type of decorated functions must be inferred (as `Any`).
+
+```python
+def identity(f):
+    return f
+
+@identity
+def foo():
+  pass
+  
+# type of foo is: Any
+```

--- a/starlark/src/analysis/flow.rs
+++ b/starlark/src/analysis/flow.rs
@@ -147,6 +147,7 @@ fn check_stmt(codemap: &CodeMap, x: &AstStmt, res: &mut Vec<LintT<FlowIssue>>) {
         Stmt::Def(DefP {
             name,
             params: _,
+            decorators: _,
             return_type,
             body,
             payload: _,

--- a/starlark/src/analysis/names.rs
+++ b/starlark/src/analysis/names.rs
@@ -506,6 +506,10 @@ impl<'a> State<'a> {
                 });
             }
             Stmt::Def(x) => {
+                // Decorator expressions are evaluated in the enclosing scope.
+                for decorator in &x.decorators {
+                    self.expr(decorator);
+                }
                 for p in &x.params {
                     p.node.visit_expr(|e| self.expr(e));
                 }
@@ -812,5 +816,81 @@ def _bar():
         );
         let res = lint(&m, Some(&HashSet::new()));
         assert_eq!(res.len(), 0);
+    }
+
+    /// Decorator expressions are evaluated in the enclosing scope and must be included in
+    /// name/reference analysis, so unused/undefined warnings fire.
+    #[test]
+    fn test_decorator_names_in_enclosing_scope() {
+        let m = module(
+            r#"
+my_decorator = lambda f: f
+@my_decorator
+def foo(): pass
+"#,
+        );
+        let res = lint(&m, Some(&HashSet::new()));
+
+        // my_decorator is used by the decorator, so no unused-assign warning.
+        assert_eq!(res.len(), 0);
+    }
+
+    #[test]
+    fn test_decorator_undefined_name_warned() {
+        let globals = HashSet::new();
+        let m = module(
+            r#"
+@undefined_decorator
+def foo(): pass
+"#,
+        );
+        let res = lint(&m, Some(&globals));
+        let undefined_names: Vec<_> = res
+            .iter()
+            .filter_map(|lint| match &lint.problem {
+                NameWarning::UsingUndefined(name) => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            undefined_names.contains(&"undefined_decorator"),
+            "expected undefined_decorator warning, got {:?}",
+            undefined_names
+        );
+    }
+
+    /// Decorator names must be tracked; unused private (e.g. underscore-prefixed) ones at module
+    /// level should warn, while used decorator names must not.
+    #[test]
+    fn test_stacked_decorator_names_tracked() {
+        let globals = HashSet::new();
+        let m = module(
+            r#"
+_used_dec = lambda f: f
+_unused_dec = lambda f: f
+@_used_dec
+def foo(): pass
+"#,
+        );
+        let res = lint(&m, Some(&globals));
+        let unused_names: Vec<_> = res
+            .iter()
+            .filter_map(|lint| match &lint.problem {
+                NameWarning::UnusedAssign(name) => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+        // _unused_dec is assigned but never referenced.
+        assert!(
+            unused_names.contains(&"_unused_dec"),
+            "expected _unused_dec warning, got {:?}",
+            unused_names
+        );
+        // _used_dec is referenced by the decorator, so no warning for it.
+        assert!(
+            !unused_names.contains(&"_used_dec"),
+            "unexpected _used_dec warning, got {:?}",
+            unused_names
+        );
     }
 }

--- a/starlark/src/eval/compiler/expr.rs
+++ b/starlark/src/eval/compiler/expr.rs
@@ -1221,7 +1221,7 @@ impl<'v, 'a, 'e> Compiler<'v, 'a, 'e, '_> {
         }
     }
 
-    fn opt_ctx<'s>(&'s mut self) -> OptCtx<'v, 'a, 'e, 's> {
+    pub(crate) fn opt_ctx<'s>(&'s mut self) -> OptCtx<'v, 'a, 'e, 's> {
         let param_count = self.current_scope().param_count();
         OptCtx::new(self.eval, param_count)
     }

--- a/starlark/src/eval/compiler/scope.rs
+++ b/starlark/src/eval/compiler/scope.rs
@@ -491,6 +491,7 @@ impl<'f> ModuleScopeBuilder<'f> {
             return_type: _,
             body,
             payload: scope_id,
+            decorators: _,
         }) = &mut code.node
         {
             // Here we traverse the AST twice: once for this def scope,
@@ -558,13 +559,20 @@ impl<'f> ModuleScopeBuilder<'f> {
                 return_type,
                 body,
                 payload: scope_id,
-            }) => self.resolve_idents_in_def(
-                *scope_id,
-                params,
-                return_type.as_mut().map(|r| &mut **r),
-                Some(body),
-                None,
-            ),
+                decorators,
+            }) => {
+                // Decorators are evaluated in the enclosing scope before entering the def.
+                for decorator in decorators {
+                    self.resolve_idents_in_expr(decorator);
+                }
+                self.resolve_idents_in_def(
+                    *scope_id,
+                    params,
+                    return_type.as_mut().map(|r| &mut **r),
+                    Some(body),
+                    None,
+                )
+            }
             StmtP::Assign(AssignP { lhs, ty, rhs }) => {
                 self.resolve_idents_in_assign(lhs);
                 if let Some(ty) = ty {

--- a/starlark/src/eval/compiler/scope/tests.rs
+++ b/starlark/src/eval/compiler/scope/tests.rs
@@ -207,3 +207,56 @@ fn existing_module_with_names() {
     module.add_name(frozen_heap.alloc_str_intern("y"));
     test_with_module("x = y", "0:m=0+ 1:m=1 | x:0 y:1", &module);
 }
+
+#[test]
+fn decorator_resolved_in_enclosing_scope() {
+    // The `dec` rhs expression must:
+    //   - resolve to the module-level binding
+    //   - not be marked as captured
+    t(
+        "\
+dec = lambda x: x
+
+@dec
+def foo(): pass",
+        "0:m=0 1:m=1 2:l=0 | dec:0 x:2 foo:1 dec:0",
+    );
+}
+
+#[test]
+fn decorator_in_nested_def_resolved_in_outer_scope() {
+    // The `dec` RHS expression must:
+    //   - resolve to the module level binding
+    //   - be marked as captured
+    t(
+        "\
+dec = lambda x: x
+
+def outer():
+    @dec
+    def inner(): pass",
+        "0:m=0& 1:m=1 2:l=0 3:l=0 | dec:0 x:2 outer:1 inner:3 dec:0",
+    );
+}
+
+#[test]
+fn decorator_shadowing() {
+    // The top-level `dec` must:
+    //   - resolve to the module level binding
+    //   - NOT be marked as captured
+    // The `dec` RHS expression must:
+    //   - resolve to the function-level binding
+    //   - NOT be marked as captured
+    t(
+        r#"
+dec = "asdf"
+
+def outer():
+    dec = lambda x: x
+
+    @dec
+    def inner(): pass
+"#,
+        "0:m=0 1:m=1 2:l=0 3:l=1 4:l=0 | dec:0 outer:1 dec:2 x:4 inner:3 dec:2",
+    );
+}

--- a/starlark/src/eval/compiler/stmt.rs
+++ b/starlark/src/eval/compiler/stmt.rs
@@ -32,6 +32,7 @@ use starlark_syntax::syntax::ast::AssignOp;
 use starlark_syntax::syntax::ast::AssignP;
 use starlark_syntax::syntax::ast::AssignTargetP;
 use starlark_syntax::syntax::ast::DefP;
+use starlark_syntax::syntax::ast::ExprP;
 use starlark_syntax::syntax::ast::ForP;
 use starlark_syntax::syntax::ast::StmtP;
 use thiserror::Error;
@@ -42,6 +43,8 @@ use crate::codemap::Spanned;
 use crate::environment::FrozenModuleData;
 use crate::environment::slots::ModuleSlotId;
 use crate::eval::compiler::Compiler;
+use crate::eval::compiler::args::ArgsCompiledValue;
+use crate::eval::compiler::call::CallCompiled;
 use crate::eval::compiler::error::CompilerInternalError;
 use crate::eval::compiler::expr::Builtin1;
 use crate::eval::compiler::expr::ExprCompiled;
@@ -53,6 +56,7 @@ use crate::eval::compiler::scope::Captured;
 use crate::eval::compiler::scope::Slot;
 use crate::eval::compiler::scope::payload::CstAssignTarget;
 use crate::eval::compiler::scope::payload::CstExpr;
+use crate::eval::compiler::scope::payload::CstPayload;
 use crate::eval::compiler::scope::payload::CstStmt;
 use crate::eval::compiler::small_vec_1::SmallVec1;
 use crate::eval::compiler::span::IrSpanned;
@@ -737,13 +741,14 @@ impl Compiler<'_, '_, '_, '_> {
                 let signature_span = def.signature_span();
                 let signature_span = FrozenFileSpan::new(self.codemap, signature_span);
                 let DefP {
+                    decorators,
                     name,
                     params,
                     return_type,
                     body,
                     payload: scope_id,
                 } = def;
-                let rhs = IrSpanned {
+                let function = IrSpanned {
                     node: self.function(
                         &name.ident,
                         signature_span,
@@ -754,6 +759,7 @@ impl Compiler<'_, '_, '_, '_> {
                     )?,
                     span,
                 };
+                let rhs = self.decorate(function, decorators, span)?;
                 let lhs = self.assign_target(&Spanned {
                     span: name.span,
                     node: AssignTargetP::Identifier(name.clone()),
@@ -821,5 +827,29 @@ impl Compiler<'_, '_, '_, '_> {
                 node: StmtCompiled::Continue,
             })),
         }
+    }
+
+    fn decorate(
+        &mut self,
+        function: IrSpanned<ExprCompiled>,
+        decorators: &[Spanned<ExprP<CstPayload>>],
+        span: FrameSpan,
+    ) -> Result<IrSpanned<ExprCompiled>, CompilerInternalError> {
+        let mut decorated = function;
+
+        // Apply decorators in reverse source order so `@a @b def f` becomes `a(b(f))`.
+        for decorator in decorators.iter().rev() {
+            let decorator_expr = self.expr(decorator)?;
+            let args = ArgsCompiledValue {
+                pos_named: vec![decorated],
+                names: vec![],
+                args: None,
+                kwargs: None,
+            };
+            let call = CallCompiled::call(span, decorator_expr, args, &mut self.opt_ctx());
+            decorated = IrSpanned { span, node: call };
+        }
+
+        Ok(decorated)
     }
 }

--- a/starlark/src/tests.rs
+++ b/starlark/src/tests.rs
@@ -20,6 +20,7 @@ mod bc;
 mod before_stmt;
 mod call;
 mod comprehension;
+mod decorator;
 mod def;
 mod derive;
 mod for_loop;

--- a/starlark/src/tests/decorator.rs
+++ b/starlark/src/tests/decorator.rs
@@ -1,0 +1,94 @@
+//! Runtime behavior tests for `def` decorators.
+
+use crate::assert::Assert;
+
+#[test]
+fn test_decorator_identity() {
+    Assert::new().pass(
+        r#"
+def identity(f):
+    return f
+
+@identity
+def fn(input):
+    return input
+
+assert_eq(fn(7), 7)
+assert_eq(fn("asdf"), "asdf")
+"#,
+    );
+}
+
+#[test]
+fn test_decorator_replaces_name() {
+    Assert::new().pass(
+        r#"
+def dec(f):
+    return None
+
+@dec
+def fn():
+    return "result of fn"
+
+# the name "fn" is now bound to the return value of dec, instead of the def
+assert_eq(fn, None)
+"#,
+    );
+}
+
+#[test]
+fn test_decorator_evaluation_order() {
+    Assert::new().pass(
+        r#"
+evaluation_order = []
+execution_order = []
+
+def dec(name):
+    def named_dec(f):
+        evaluation_order.append(name)
+        return f
+    return named_dec
+
+@dec("a")
+@dec("b")
+@dec("c")
+def my_func():
+    pass
+
+# evaluation order must be inside-out
+assert_eq(evaluation_order, ["c", "b", "a"])
+"#,
+    );
+}
+
+#[test]
+fn test_decorator_non_callable_fails() {
+    Assert::new().fails(
+        r#"
+not_callable = 99
+
+@not_callable
+def should_fail():
+    return
+        "#,
+        &["Operation `call()` not supported on type `int`"],
+    );
+}
+
+#[test]
+fn test_decorator_forwards_args() {
+    Assert::new().pass(
+        r#"
+def logged(f):
+    def wrapper(*args, **kwargs):
+        return f(*args, **kwargs)
+    return wrapper
+
+@logged
+def add(x, y):
+    return x + y
+
+assert_eq(add(3, 4), 7)
+"#,
+    );
+}

--- a/starlark/src/typing/bindings.rs
+++ b/starlark/src/typing/bindings.rs
@@ -67,6 +67,8 @@ pub(crate) enum BindExpr<'a> {
     SetIndex(BindingId, &'a CstExpr, Box<BindExpr<'a>>),
     ListAppend(BindingId, &'a CstExpr),
     ListExtend(BindingId, &'a CstExpr),
+    /// Apply decorators ([`&[CstExpr]`], in source order) to a function of "base" type [`Ty`].
+    DecoratorApply(&'a [CstExpr], Ty),
 }
 
 impl<'a> BindExpr<'a> {
@@ -79,6 +81,15 @@ impl<'a> BindExpr<'a> {
             BindExpr::SetIndex(_, x, _) => x.span,
             BindExpr::ListAppend(_, x) => x.span,
             BindExpr::ListExtend(_, x) => x.span,
+            BindExpr::DecoratorApply(decorators, _) => {
+                assert!(
+                    decorators.is_empty(),
+                    "Bug in the starlark crate: BindExpr::DecoratorApply used with no decorators."
+                );
+                let first = &decorators[0];
+                let last = &decorators[decorators.len() - 1];
+                first.span.merge(last.span)
+            }
         }
     }
 }
@@ -213,6 +224,7 @@ impl<'a, 'b> BindingsCollect<'a, 'b> {
         codemap: &CodeMap,
     ) -> Result<(), InternalError> {
         let DefP {
+            decorators,
             name,
             params,
             return_type,
@@ -279,10 +291,20 @@ impl<'a, 'b> BindingsCollect<'a, 'b> {
         let params2 = ParamSpec::new_parts(pos_only, pos_or_named, args, named_only, kwargs)
             .map_err(|e| InternalError::from_error(e, def.signature_span(), codemap))?;
         let ret_ty = Self::resolve_ty_opt(return_type.as_deref(), typecheck_mode, codemap)?;
-        self.bindings.types.insert(
-            name.resolved_binding_id(codemap)?,
-            Ty::function(params2, ret_ty.clone()),
-        );
+        let base_fn_ty = Ty::function(params2, ret_ty.clone());
+        let binding_id = name.resolved_binding_id(codemap)?;
+        if decorators.is_empty() {
+            // No decorators: register the base function type directly (type is fully known
+            // from annotations).
+            self.bindings.types.insert(binding_id, base_fn_ty);
+        } else {
+            // Decorators present: the final type needs to be inferred from decorator calls.
+            self.bindings
+                .expressions
+                .entry(binding_id)
+                .or_default()
+                .push(BindExpr::DecoratorApply(decorators.as_slice(), base_fn_ty));
+        }
         def.visit_children_err(|x| self.visit(x, &ret_ty, typecheck_mode, codemap))?;
         Ok(())
     }

--- a/starlark/src/typing/ctx.rs
+++ b/starlark/src/typing/ctx.rs
@@ -229,6 +229,21 @@ impl TypingContext<'_> {
                     Ok(Ty::never())
                 }
             }
+            BindExpr::DecoratorApply(decorators, base_fn_ty) => {
+                let mut ty = base_fn_ty.clone();
+                for decorator in decorators.iter().rev() {
+                    let span = decorator.span;
+                    let decorator_ty = self.expression_type(decorator)?;
+                    let args = TyCallArgs {
+                        pos: vec![Spanned { node: ty, span }],
+                        named: vec![],
+                        args: None,
+                        kwargs: None,
+                    };
+                    ty = self.validate_call(&decorator_ty, &args, span)?;
+                }
+                Ok(ty)
+            }
         }
     }
 

--- a/starlark/src/typing/fill_types_for_lint.rs
+++ b/starlark/src/typing/fill_types_for_lint.rs
@@ -57,9 +57,11 @@ use crate::typing::Approximation;
 use crate::typing::ParamSpec;
 use crate::typing::Ty;
 use crate::typing::TypingOracleCtx;
+use crate::typing::call_args::TyCallArgs;
 use crate::typing::callable_param::ParamIsRequired;
 use crate::typing::error::InternalError;
 use crate::typing::error::TypingError;
+use crate::typing::error::TypingOrInternalError;
 use crate::util::arc_str::ArcStr;
 use crate::values::Heap;
 use crate::values::Value;
@@ -482,7 +484,42 @@ impl<'a, 'v> GlobalTypesBuilder<'a, 'v> {
         let params = ParamSpec::new_parts(pos_only, pos_or_name, args, name_only, kwargs)
             .map_err(|e| InternalError::from_error(e, def.signature_span(), self.ctx.codemap))?;
 
-        self.assign_ident_value(&def.name, GlobalValue::ty(Ty::function(params, result)))
+        let fn_ty = self.apply_decorators(def, result, params)?;
+
+        self.assign_ident_value(&def.name, GlobalValue::ty(fn_ty))
+    }
+
+    fn apply_decorators(
+        &mut self,
+        def: &DefP<CstPayload>,
+        return_ty: Ty,
+        params: ParamSpec,
+    ) -> Result<Ty, InternalError> {
+        let mut fn_ty = Ty::function(params, return_ty);
+        for decorator in def.decorators.iter().rev() {
+            let span = decorator.span;
+            let decorator_val = self.expr(decorator)?;
+            let decorator_ty = decorator_val.ty;
+            let args = TyCallArgs {
+                pos: vec![Spanned { node: fn_ty, span }],
+                named: vec![],
+                args: None,
+                kwargs: None,
+            };
+            fn_ty = match self.ctx.validate_call(span, &decorator_ty, &args) {
+                Ok(ty) => ty,
+                Err(TypingOrInternalError::Typing(e)) => {
+                    // Record the error, but return the resulting type as Any to avoid further
+                    // errors down the line.
+                    self.errors.push(e);
+                    Ty::any()
+                }
+                Err(TypingOrInternalError::Internal(e)) => {
+                    return Err(e);
+                }
+            };
+        }
+        Ok(fn_ty)
     }
 
     fn eval_stmt(&mut self, stmt: &CstStmt) -> Result<(), InternalError> {

--- a/starlark/src/typing/tests.rs
+++ b/starlark/src/typing/tests.rs
@@ -57,6 +57,7 @@ use crate::values::typing::StarlarkIter;
 
 mod call;
 mod callable;
+mod decorator;
 mod list;
 mod special_function;
 mod tuple;

--- a/starlark/src/typing/tests/decorator.rs
+++ b/starlark/src/typing/tests/decorator.rs
@@ -1,0 +1,79 @@
+//! Tests for `def` decorators.
+
+use crate::typing::tests::TypeCheck;
+
+/// The return type of the decorator determines the type of the decorated name.
+#[test]
+fn test_decorator_replaces_type() {
+    TypeCheck::new().ty("fn").check(
+        "decorator_replaces_type",
+        r#"
+def actually_an_integer(f) -> int:
+    return 42
+
+@actually_an_integer
+def fn(x: str) -> bool:
+    return True
+"#,
+    );
+}
+
+/// An untyped decorator binds the name of the decorated function to typing.Any.
+#[test]
+fn untyped_returns_any() {
+    TypeCheck::new().ty("fn").check(
+        "decorator_without_type_hints_returns_any",
+        r#"
+def identity(f):
+    return f
+
+@identity
+def fn(x: int) -> str:
+    return str(x)
+
+def fn_should_still_be_callable():
+    fn(23)
+"#,
+    );
+}
+
+/// Stacked decorators: the outermost decorator's return type is the binding type.
+#[test]
+fn test_decorator_stacked_type() {
+    TypeCheck::new().ty("fn").check(
+        "decorator_stacked_type",
+        r#"
+def outer_dec(f) -> int:
+    return 0
+
+def inner_dec(f):
+    return f
+
+@outer_dec
+@inner_dec
+def fn(x: str) -> bool:
+    return True
+"#,
+    );
+}
+
+/// A decorator factory: `@make_decorator(arg)` — the result of calling `make_decorator(arg)` is
+/// applied as a decorator and the type of `fn` is the return type of the callable returned by
+/// `make_decorator`.
+#[test]
+fn test_decorator_factory_type() {
+    TypeCheck::new().ty("fn").check(
+        "decorator_factory_type",
+        r#"
+def make_decorator(label: str) -> typing.Callable[[typing.Callable], str]:
+    def decorator(f):
+        f()
+        return label
+    return decorator
+
+@make_decorator("hello")
+def fn(x: int) -> int:
+    return x
+"#,
+    );
+}

--- a/starlark/src/typing/tests/golden/decorator_factory_type.golden
+++ b/starlark/src/typing/tests/golden/decorator_factory_type.golden
@@ -1,0 +1,36 @@
+# @generated
+# To regenerate, run:
+# ```
+# STARLARK_RUST_REGENERATE_GOLDEN_TESTS=1 cargo test -p starlark --lib
+# ```
+
+Code:
+def make_decorator(label: str) -> typing.Callable[[typing.Callable], str]:
+    def decorator(f):
+        f()
+        return label
+    return decorator
+
+@make_decorator("hello")
+def fn(x: int) -> int:
+    return x
+
+No errors.
+
+Types:
+fn: str
+
+Compiler typechecker (eval):
+Compiler typechecker and eval results mismatch.
+
+Traceback (most recent call last):
+  * filename:8, in <module>
+      @make_decorator("hello")
+  * filename:4, in decorator
+      f()
+error: Missing parameter `x` for call to `filename.fn`
+ --> filename:4:9
+  |
+4 |         f()
+  |         ^^^
+  |

--- a/starlark/src/typing/tests/golden/decorator_replaces_type.golden
+++ b/starlark/src/typing/tests/golden/decorator_replaces_type.golden
@@ -1,0 +1,21 @@
+# @generated
+# To regenerate, run:
+# ```
+# STARLARK_RUST_REGENERATE_GOLDEN_TESTS=1 cargo test -p starlark --lib
+# ```
+
+Code:
+def actually_an_integer(f) -> int:
+    return 42
+
+@actually_an_integer
+def fn(x: str) -> bool:
+    return True
+
+No errors.
+
+Types:
+fn: int
+
+Compiler typechecker (eval):
+No errors.

--- a/starlark/src/typing/tests/golden/decorator_stacked_type.golden
+++ b/starlark/src/typing/tests/golden/decorator_stacked_type.golden
@@ -1,0 +1,25 @@
+# @generated
+# To regenerate, run:
+# ```
+# STARLARK_RUST_REGENERATE_GOLDEN_TESTS=1 cargo test -p starlark --lib
+# ```
+
+Code:
+def outer_dec(f) -> int:
+    return 0
+
+def inner_dec(f):
+    return f
+
+@outer_dec
+@inner_dec
+def fn(x: str) -> bool:
+    return True
+
+No errors.
+
+Types:
+fn: int
+
+Compiler typechecker (eval):
+No errors.

--- a/starlark/src/typing/tests/golden/decorator_without_type_hints_returns_any.golden
+++ b/starlark/src/typing/tests/golden/decorator_without_type_hints_returns_any.golden
@@ -1,0 +1,24 @@
+# @generated
+# To regenerate, run:
+# ```
+# STARLARK_RUST_REGENERATE_GOLDEN_TESTS=1 cargo test -p starlark --lib
+# ```
+
+Code:
+def identity(f):
+    return f
+
+@identity
+def fn(x: int) -> str:
+    return str(x)
+
+def fn_should_still_be_callable():
+    fn(23)
+
+No errors.
+
+Types:
+fn: typing.Any
+
+Compiler typechecker (eval):
+No errors.

--- a/starlark_lsp/src/bind.rs
+++ b/starlark_lsp/src/bind.rs
@@ -278,10 +278,14 @@ fn stmt(x: &AstStmt, res: &mut Vec<Bind>) {
         Stmt::Def(DefP {
             name,
             params,
+            decorators,
             return_type,
             body,
             payload: _,
         }) => {
+            for decorator in decorators {
+                expr(decorator, res);
+            }
             opt_type_expr(return_type.as_ref().map(|x| &**x), res);
             let mut inner = Vec::new();
             parameters(params, res, &mut inner);
@@ -383,6 +387,69 @@ mod tests {
             .collect::<anyhow::Result<Vec<Vec<_>>>>()?;
 
         assert_eq!(expected, found_bindings);
+
+        Ok(())
+    }
+
+    #[test]
+    fn decorator_bindings_are_correct() -> starlark::Result<()> {
+        let contents = "@my_decorator\ndef foo(): pass";
+        let module = AstModule::parse(
+            "foo.star",
+            contents.to_owned(),
+            &Dialect::AllOptionsInternal,
+        )?;
+        let scope = scope(&module);
+
+        let has_decorator_get = scope.inner.iter().any(|b| match b {
+            Bind::Get(id) => id.node.ident == "my_decorator",
+            _ => false,
+        });
+        assert!(has_decorator_get, "decorator should appear as Bind::Get");
+
+        let has_fn_set = scope.inner.iter().any(|b| match b {
+            Bind::Set(Assigner::Assign, id) => id.ident == "foo",
+            _ => false,
+        });
+        assert!(has_fn_set, "function name should appear as Bind::Set");
+
+        assert!(
+            scope.free.contains_key("my_decorator"),
+            "decorator should be a free variable"
+        );
+        assert!(
+            scope.bound.contains_key("foo"),
+            "function name should be bound"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn dotted_decorator_bindings_are_correct() -> starlark::Result<()> {
+        let contents = "@obj.decorator\ndef foo(): pass";
+        let module = AstModule::parse(
+            "foo.star",
+            contents.to_owned(),
+            &Dialect::AllOptionsInternal,
+        )?;
+        let scope = scope(&module);
+
+        let has_dotted_get = scope.inner.iter().any(|b| match b {
+            Bind::GetDotted(gd) => {
+                gd.variable.node.ident == "obj"
+                    && gd.attributes.len() == 1
+                    && gd.attributes[0].node == "decorator"
+            }
+            _ => false,
+        });
+        assert!(
+            has_dotted_get,
+            "dotted decorator should appear as Bind::GetDotted"
+        );
+
+        assert!(scope.free.contains_key("obj"), "'obj' should be free");
+        assert!(scope.bound.contains_key("foo"), "'foo' should be bound");
 
         Ok(())
     }

--- a/starlark_syntax/src/dialect.rs
+++ b/starlark_syntax/src/dialect.rs
@@ -37,6 +37,9 @@ pub struct Dialect {
     /// Are `def` statements permitted.
     /// Enabled by default.
     pub enable_def: bool,
+    /// Are function decorators expressions (as per [PEP 614](https://peps.python.org/pep-0614/)) permitted.
+    /// Disabled by default.
+    pub enable_decorators: bool,
     /// Are `lambda` expressions permitted.
     /// Enabled by default.
     pub enable_lambda: bool,
@@ -85,6 +88,7 @@ impl Dialect {
     /// This is also returned by [`Dialect::default()`](Dialect::default).
     pub const Standard: Self = Self {
         enable_def: true,
+        enable_decorators: false,
         enable_lambda: true,
         enable_load: true,
         enable_keyword_only_arguments: false,
@@ -100,6 +104,7 @@ impl Dialect {
     #[doc(hidden)]
     pub const Extended: Self = Self {
         enable_def: true,
+        enable_decorators: true,
         enable_lambda: true,
         enable_load: true,
         enable_keyword_only_arguments: true,
@@ -115,6 +120,7 @@ impl Dialect {
     #[doc(hidden)]
     pub const AllOptionsInternal: Self = Self {
         enable_def: true,
+        enable_decorators: true,
         enable_lambda: true,
         enable_load: true,
         enable_keyword_only_arguments: true,

--- a/starlark_syntax/src/lexer.rs
+++ b/starlark_syntax/src/lexer.rs
@@ -1355,6 +1355,8 @@ pub enum Token {
     #[token("return")]
     Return,
     // Symbols
+    #[token("@")]
+    At,
     #[token(",")]
     Comma,
     #[token(";")]
@@ -1496,6 +1498,7 @@ impl Display for Token {
             Token::Elif => write!(f, "keyword 'elif'"),
             Token::Return => write!(f, "keyword 'return'"),
             Token::Lambda => write!(f, "keyword 'lambda'"),
+            Token::At => write!(f, "symbol '@'"),
             Token::Comma => write!(f, "symbol ','"),
             Token::Semicolon => write!(f, "symbol ';'"),
             Token::Colon => write!(f, "symbol ':'"),

--- a/starlark_syntax/src/syntax/ast.rs
+++ b/starlark_syntax/src/syntax/ast.rs
@@ -348,6 +348,7 @@ pub enum Visibility {
 
 #[derive(Debug, Clone)]
 pub struct DefP<P: AstPayload> {
+    pub decorators: Vec<AstExprP<P>>, // in source order
     pub name: AstAssignIdentP<P>,
     pub params: Vec<AstParameterP<P>>,
     pub return_type: Option<Box<AstTypeExprP<P>>>,
@@ -757,12 +758,16 @@ impl Stmt {
                 body.node.fmt_with_tab(f, tab + "  ")
             }
             Stmt::Def(DefP {
+                decorators,
                 name,
                 params,
                 return_type,
                 body,
                 payload: _,
             }) => {
+                for decorator in decorators {
+                    writeln!(f, "{}@{}", tab, decorator.node)?;
+                }
                 write!(f, "{}def {}(", tab, name.node)?;
                 comma_separated_fmt(f, params, |x, f| write!(f, "{}", x.node), false)?;
                 f.write_str(")")?;

--- a/starlark_syntax/src/syntax/grammar_tests.rs
+++ b/starlark_syntax/src/syntax/grammar_tests.rs
@@ -233,6 +233,111 @@ fn test_top_level_def() {
 }
 
 #[test]
+fn test_top_level_def_decorated() {
+    fn roundtrip(code: &str) {
+        assert_eq!(parse(code), code);
+    }
+
+    // Single decorator in multiple forms
+    for decoration in [
+        "@x",
+        "@(x, y)",
+        "@x[y]",
+        "@w[x].y.z",
+        "@x(y)()(z)",
+        "@[w, x, y][z]",
+        "@x.y",
+        "@x(y)",
+        "@(lambda x: x)",
+    ] {
+        roundtrip(format!("{decoration}\ndef fn():\n  pass\n").as_str())
+    }
+
+    // Stacked decorators preserve order
+    roundtrip("@a\n@b\n@c\ndef foo():\n  pass\n");
+    // Decorator combined with type hints
+    roundtrip("@my_dec\ndef foo(x: int, y: str) -> bool:\n  return True\n");
+    // Decorated def is rejected when `def` is disabled in the dialect.
+    parse_fail_with_dialect(
+        "decorator_def_disabled",
+        &Dialect {
+            enable_def: false,
+            ..Dialect::AllOptionsInternal
+        },
+        "@my_dec\ndef toto():\n  pass",
+    );
+    // `lambda` used as a decorator expression is rejected when lambdas are disabled.
+    parse_fail_with_dialect(
+        "decorator_lambda_disabled",
+        &Dialect {
+            enable_lambda: false,
+            ..Dialect::AllOptionsInternal
+        },
+        "@(lambda x: x)\ndef foo():\n  pass",
+    );
+    // Decorated def is rejected when `enable_decorators` is false.
+    parse_fail_with_dialect(
+        "decorator_disabled",
+        &Dialect {
+            enable_decorators: false,
+            ..Dialect::AllOptionsInternal
+        },
+        "@my_dec\ndef foo():\n  pass",
+    );
+    // Stacked decorators: error points at the first decorator.
+    // FIXME: Should that be the case?
+    parse_fail_with_dialect(
+        "decorator_disabled_stacked",
+        &Dialect {
+            enable_decorators: false,
+            ..Dialect::AllOptionsInternal
+        },
+        "@dec_a\n@dec_b\n@dec_c\ndef foo():\n  pass",
+    );
+}
+
+#[test]
+fn test_decorator_span_in_ast() {
+    // Verify that a decorated def AST node has the decorator list populated
+    // and that spans are non-empty.
+    let ast = parse_ast("@my_dec\ndef foo():\n  pass\n");
+    match &ast.statement.node {
+        Stmt::Def(def) => {
+            assert_eq!(def.decorators.len(), 1, "expected 1 decorator");
+            // The decorator span must start at the `m` of `my_dec` (offset 1).
+            assert_eq!(
+                ast.codemap.source_span(def.decorators[0].span),
+                "my_dec",
+                "decorator span source mismatch"
+            );
+        }
+        other => panic!("expected Def statement, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_stacked_decorator_order_in_ast() {
+    use crate::syntax::ast::Stmt;
+    let ast = parse_ast("@first\n@second\ndef foo():\n  pass\n");
+    match &ast.statement.node {
+        Stmt::Def(def) => {
+            assert_eq!(def.decorators.len(), 2, "expected 2 decorators");
+            assert_eq!(
+                ast.codemap.source_span(def.decorators[0].span),
+                "first",
+                "first decorator span mismatch"
+            );
+            assert_eq!(
+                ast.codemap.source_span(def.decorators[1].span),
+                "second",
+                "second decorator span mismatch"
+            );
+        }
+        other => panic!("expected Def statement, got {other:?}"),
+    }
+}
+
+#[test]
 fn test_top_level_statements() {
     let no_top_leve_stmt = Dialect {
         enable_top_level_stmt: false,
@@ -791,6 +896,21 @@ fn test_error_tuple_trailing_comma() {
             "a, b = 1, 2,",
         ],
     );
+}
+
+#[test]
+fn test_decorator_parse_error_points_at_offending_token() {
+    // A bare `@` with no expression (just newline) produces a parse error whose
+    // span points at the newline, which is the first unexpected token after `@`.
+    assert_parse_error_span_source("@\ndef foo():\n  pass\n", "\n");
+
+    // When trying to put multiple decorators on the same line, the error message
+    // should point at the (second) `@`.
+    assert_parse_error_span_source("@a @b\ndef foo():\n    pass\n", "@");
+
+    // A decorator with no following `def` produces an error pointing at the
+    // unexpected next statement.
+    assert_parse_error_span_source("@my_dec\nx = 1\n", "x");
 }
 
 pub fn parse(program: &str) -> String {

--- a/starlark_syntax/src/syntax/grammar_tests/decorator_def_disabled.golden
+++ b/starlark_syntax/src/syntax/grammar_tests/decorator_def_disabled.golden
@@ -1,0 +1,20 @@
+# @generated
+# To regenerate, run:
+# ```
+# STARLARK_RUST_REGENERATE_GOLDEN_TESTS=1 cargo test -p starlark --lib
+# ```
+
+Program:
+@my_dec
+def toto():
+  pass
+
+Error:
+error: `def` is not allowed in this dialect
+ --> decorator_def_disabled:1:1
+  |
+1 | / @my_dec
+2 | | def toto():
+3 | |   pass
+  | |______^
+  |

--- a/starlark_syntax/src/syntax/grammar_tests/decorator_disabled.golden
+++ b/starlark_syntax/src/syntax/grammar_tests/decorator_disabled.golden
@@ -1,0 +1,18 @@
+# @generated
+# To regenerate, run:
+# ```
+# STARLARK_RUST_REGENERATE_GOLDEN_TESTS=1 cargo test -p starlark --lib
+# ```
+
+Program:
+@my_dec
+def foo():
+  pass
+
+Error:
+error: decorator expressions are not allowed in this dialect
+ --> decorator_disabled:1:2
+  |
+1 | @my_dec
+  |  ^^^^^^
+  |

--- a/starlark_syntax/src/syntax/grammar_tests/decorator_disabled_stacked.golden
+++ b/starlark_syntax/src/syntax/grammar_tests/decorator_disabled_stacked.golden
@@ -1,0 +1,23 @@
+# @generated
+# To regenerate, run:
+# ```
+# STARLARK_RUST_REGENERATE_GOLDEN_TESTS=1 cargo test -p starlark --lib
+# ```
+
+Program:
+@dec_a
+@dec_b
+@dec_c
+def foo():
+  pass
+
+Error:
+error: decorator expressions are not allowed in this dialect
+ --> decorator_disabled_stacked:1:2
+  |
+1 |   @dec_a
+  |  __^
+2 | | @dec_b
+3 | | @dec_c
+  | |______^
+  |

--- a/starlark_syntax/src/syntax/grammar_tests/decorator_lambda_disabled.golden
+++ b/starlark_syntax/src/syntax/grammar_tests/decorator_lambda_disabled.golden
@@ -1,0 +1,18 @@
+# @generated
+# To regenerate, run:
+# ```
+# STARLARK_RUST_REGENERATE_GOLDEN_TESTS=1 cargo test -p starlark --lib
+# ```
+
+Program:
+@(lambda x: x)
+def foo():
+  pass
+
+Error:
+error: `lambda` is not allowed in this dialect
+ --> decorator_lambda_disabled:1:3
+  |
+1 | @(lambda x: x)
+  |   ^^^^^^^^^^^
+  |

--- a/starlark_syntax/src/syntax/parser_rd.rs
+++ b/starlark_syntax/src/syntax/parser_rd.rs
@@ -226,7 +226,7 @@ impl<'a, I: Iterator<Item = Lexeme>> ParserRd<'a, I> {
 
     fn parse_stmt(&mut self) -> Result<AstStmt, EvalException> {
         match self.peek() {
-            Some(Token::Def) => self.parse_def_stmt(),
+            Some(Token::Def) | Some(Token::At) => self.parse_def_stmt(),
             Some(Token::If) => self.parse_if_stmt(),
             Some(Token::For) => self.parse_for_stmt(),
             _ => self.parse_simple_stmt(),
@@ -235,7 +235,8 @@ impl<'a, I: Iterator<Item = Lexeme>> ParserRd<'a, I> {
 
     fn parse_def_stmt(&mut self) -> Result<AstStmt, EvalException> {
         let l = self.pos();
-        self.consume(&Token::Def);
+        let decorators = self.parse_decorators()?;
+        self.expect(&Token::Def)?;
         let name = self.parse_assign_ident()?;
         self.expect(&Token::OpeningRound)?;
         let params = self.parse_comma_separated_def_params()?;
@@ -252,6 +253,7 @@ impl<'a, I: Iterator<Item = Lexeme>> ParserRd<'a, I> {
             name,
             params,
             return_type,
+            decorators,
             body: Box::new(body),
             payload: (),
         })
@@ -1170,6 +1172,17 @@ impl<'a, I: Iterator<Item = Lexeme>> ParserRd<'a, I> {
                 payload: (),
             },
         })
+    }
+
+    fn parse_decorators(&mut self) -> Result<Vec<Spanned<ExprP<AstNoPayload>>>, EvalException> {
+        let mut decorators = Vec::new();
+        while matches!(self.peek(), Some(Token::At)) {
+            self.consume(&Token::At);
+            let decorator = self.parse_expr(0)?;
+            decorators.push(decorator);
+            self.expect(&Token::Newline)?;
+        }
+        Ok(decorators)
     }
 
     fn parse_string_literal(&mut self) -> Result<AstString, EvalException> {

--- a/starlark_syntax/src/syntax/payload_map.rs
+++ b/starlark_syntax/src/syntax/payload_map.rs
@@ -146,12 +146,14 @@ impl<A: AstPayload> StmtP<A> {
             }
             StmtP::For(fr) => StmtP::For(fr.into_map_payload(f)),
             StmtP::Def(DefP {
+                decorators,
                 name,
                 params,
                 return_type,
                 body,
                 payload,
             }) => StmtP::Def(DefP {
+                decorators: decorators.into_map(|d| d.into_map_payload(f)),
                 name: name.into_map_payload(f),
                 params: params.into_map(|p| p.into_map_payload(f)),
                 return_type: return_type.map(|ret| Box::new(ret.into_map_payload(f))),

--- a/starlark_syntax/src/syntax/uniplate.rs
+++ b/starlark_syntax/src/syntax/uniplate.rs
@@ -71,12 +71,14 @@ impl<'a, P: AstPayload> Visit<'a, P> {
 impl<P: AstPayload> DefP<P> {
     fn visit_children<'a>(&'a self, mut f: impl FnMut(Visit<'a, P>)) {
         let DefP {
+            decorators,
             name: _,
             params,
             return_type,
             body,
             payload: _,
         } = self;
+        decorators.iter().for_each(|x| f(Visit::Expr(x)));
         params
             .iter()
             .for_each(|x| x.visit_expr(|x| f(Visit::Expr(x))));
@@ -155,12 +157,14 @@ impl<P: AstPayload> StmtP<P> {
                 f(VisitMut::Stmt(else_block));
             }
             StmtP::Def(DefP {
+                decorators,
                 name: _,
                 params,
                 return_type,
                 body,
                 payload: _,
             }) => {
+                decorators.iter_mut().for_each(|x| f(VisitMut::Expr(x)));
                 params
                     .iter_mut()
                     .for_each(|x| x.visit_expr_mut(|x| f(VisitMut::Expr(x))));

--- a/starlark_syntax/src/syntax/validate.rs
+++ b/starlark_syntax/src/syntax/validate.rs
@@ -104,9 +104,24 @@ pub(crate) fn validate_module(stmt: &AstStmt, parser_state: &mut ParserState) {
         let span = stmt.span;
 
         match &stmt.node {
-            Stmt::Def(DefP { params, body, .. }) => {
+            Stmt::Def(DefP {
+                decorators,
+                params,
+                body,
+                ..
+            }) => {
                 if !parser_state.dialect.enable_def {
                     parser_state.error(span, "`def` is not allowed in this dialect");
+                }
+                if !parser_state.dialect.enable_decorators && !decorators.is_empty() {
+                    let first = &decorators[0];
+                    let last = &decorators[decorators.len() - 1];
+                    let span = first.span.merge(last.span);
+
+                    parser_state.error(
+                        span,
+                        "decorator expressions are not allowed in this dialect",
+                    );
                 }
                 validate_params(params, parser_state);
                 f(body, parser_state, false, false, true)


### PR DESCRIPTION
These allow us to write patterns where functions definitions are passed through other functions more concisely, e.g.:

```python
def func():
    ...
func = register(func)
```

is equivalent to

```python
@register
def func():
    ...
```

Depending on the API design, I find this to be highly useful for avoiding boilerplate. It is not part of the official Starlark specification though, and an inquiry from a few years ago suggests it is unlikely to land, see [1].

[1]: https://github.com/bazelbuild/starlark/issues/177