### PR TITLE
Do not report misplaced-load lint in WORKSPACE files

### DIFF
--- a/starlark/src/analysis/flow.rs
+++ b/starlark/src/analysis/flow.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use std::path::Path;
+
 use starlark_syntax::syntax::ast::AstExpr;
 use starlark_syntax::syntax::ast::AstLiteral;
 use starlark_syntax::syntax::ast::AstStmt;
@@ -271,7 +273,18 @@ fn redundant(codemap: &CodeMap, x: &AstStmt, res: &mut Vec<LintT<FlowIssue>>) {
     x.visit_stmt(|x| f(codemap, x, res));
 }
 
+fn is_workspace_file(filename: &str) -> bool {
+    Path::new(filename)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| matches!(name, "WORKSPACE" | "WORKSPACE.bazel"))
+}
+
 fn misplaced_load(codemap: &CodeMap, x: &AstStmt, res: &mut Vec<LintT<FlowIssue>>) {
+    if is_workspace_file(codemap.filename()) {
+        return;
+    }
+
     // accumulate all statements at the top-level
     fn top_statements<'a>(x: &'a AstStmt, stmts: &mut Vec<&'a AstStmt>) {
         match &**x {
@@ -333,8 +346,12 @@ mod tests {
     use super::*;
     use crate::syntax::Dialect;
 
+    fn module_with_name(name: &str, x: &str) -> AstModule {
+        AstModule::parse(name, x.to_owned(), &Dialect::AllOptionsInternal).unwrap()
+    }
+
     fn module(x: &str) -> AstModule {
-        AstModule::parse("X", x.to_owned(), &Dialect::AllOptionsInternal).unwrap()
+        module_with_name("X", x)
     }
 
     impl FlowIssue {
@@ -497,6 +514,38 @@ load("c", "b")
         let mut res = Vec::new();
         misplaced_load(m.codemap(), m.statement(), &mut res);
         assert_eq!(res.len(), 1);
+    }
+
+    #[test]
+    fn test_lint_misplaced_load_workspace() {
+        let m = module_with_name(
+            "WORKSPACE",
+            r#"
+http_archive(
+    name = "x",
+)
+load("//:defs.bzl", "defs")
+"#,
+        );
+        let mut res = Vec::new();
+        misplaced_load(m.codemap(), m.statement(), &mut res);
+        assert!(res.is_empty());
+    }
+
+    #[test]
+    fn test_lint_misplaced_load_workspace_bazel() {
+        let m = module_with_name(
+            "/repo/WORKSPACE.bazel",
+            r#"
+local_repository(
+    name = "x",
+)
+load("//:defs.bzl", "defs")
+"#,
+        );
+        let mut res = Vec::new();
+        misplaced_load(m.codemap(), m.statement(), &mut res);
+        assert!(res.is_empty());
     }
 
     #[test]

--- a/starlark/src/analysis/flow.rs
+++ b/starlark/src/analysis/flow.rs
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-use std::path::Path;
-
 use starlark_syntax::syntax::ast::AstExpr;
 use starlark_syntax::syntax::ast::AstLiteral;
 use starlark_syntax::syntax::ast::AstStmt;
@@ -273,18 +271,7 @@ fn redundant(codemap: &CodeMap, x: &AstStmt, res: &mut Vec<LintT<FlowIssue>>) {
     x.visit_stmt(|x| f(codemap, x, res));
 }
 
-fn is_workspace_file(filename: &str) -> bool {
-    Path::new(filename)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| matches!(name, "WORKSPACE" | "WORKSPACE.bazel"))
-}
-
 fn misplaced_load(codemap: &CodeMap, x: &AstStmt, res: &mut Vec<LintT<FlowIssue>>) {
-    if is_workspace_file(codemap.filename()) {
-        return;
-    }
-
     // accumulate all statements at the top-level
     fn top_statements<'a>(x: &'a AstStmt, stmts: &mut Vec<&'a AstStmt>) {
         match &**x {
@@ -334,7 +321,9 @@ pub(crate) fn lint(module: &AstModule) -> Vec<LintT<FlowIssue>> {
     stmt(module.codemap(), module.statement(), &mut res);
     reachable(module.codemap(), module.statement(), &mut res);
     redundant(module.codemap(), module.statement(), &mut res);
-    misplaced_load(module.codemap(), module.statement(), &mut res);
+    if !module.dialect().enable_load_after_statement {
+        misplaced_load(module.codemap(), module.statement(), &mut res);
+    }
     no_effect(module.codemap(), module.statement(), &mut res);
     res
 }
@@ -346,8 +335,12 @@ mod tests {
     use super::*;
     use crate::syntax::Dialect;
 
+    fn module_with_dialect(name: &str, x: &str, dialect: &Dialect) -> AstModule {
+        AstModule::parse(name, x.to_owned(), dialect).unwrap()
+    }
+
     fn module_with_name(name: &str, x: &str) -> AstModule {
-        AstModule::parse(name, x.to_owned(), &Dialect::AllOptionsInternal).unwrap()
+        module_with_dialect(name, x, &Dialect::AllOptionsInternal)
     }
 
     fn module(x: &str) -> AstModule {
@@ -517,35 +510,26 @@ load("c", "b")
     }
 
     #[test]
-    fn test_lint_misplaced_load_workspace() {
-        let m = module_with_name(
-            "WORKSPACE",
-            r#"
-http_archive(
-    name = "x",
-)
-load("//:defs.bzl", "defs")
-"#,
-        );
-        let mut res = Vec::new();
-        misplaced_load(m.codemap(), m.statement(), &mut res);
-        assert!(res.is_empty());
-    }
-
-    #[test]
-    fn test_lint_misplaced_load_workspace_bazel() {
-        let m = module_with_name(
-            "/repo/WORKSPACE.bazel",
+    fn test_lint_misplaced_load_allowed_by_dialect() {
+        let dialect = Dialect {
+            enable_load_after_statement: true,
+            ..Dialect::AllOptionsInternal
+        };
+        let m = module_with_dialect(
+            "X",
             r#"
 local_repository(
     name = "x",
 )
 load("//:defs.bzl", "defs")
 "#,
+            &dialect,
         );
-        let mut res = Vec::new();
-        misplaced_load(m.codemap(), m.statement(), &mut res);
-        assert!(res.is_empty());
+        assert!(
+            lint(&m)
+                .into_iter()
+                .all(|lint| !matches!(lint.problem, FlowIssue::MisplacedLoad))
+        );
     }
 
     #[test]

--- a/starlark_bin/bin/bazel.rs
+++ b/starlark_bin/bin/bazel.rs
@@ -176,7 +176,23 @@ pub(crate) struct BazelContext<'v> {
 impl<'v> BazelContext<'v> {
     const DEFAULT_WORKSPACE_NAME: &'static str = "__main__";
     const BUILD_FILE_NAMES: [&'static str; 2] = ["BUILD", "BUILD.bazel"];
+    const WORKSPACE_FILE_NAMES: [&'static str; 2] = ["WORKSPACE", "WORKSPACE.bazel"];
     const LOADABLE_EXTENSIONS: [&'static str; 1] = ["bzl"];
+
+    fn is_workspace_file(filename: &str) -> bool {
+        Path::new(filename)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| Self::WORKSPACE_FILE_NAMES.contains(&name))
+    }
+
+    fn dialect_for_file(&self, filename: &str) -> Dialect {
+        let mut dialect = self.dialect.clone();
+        if Self::is_workspace_file(filename) {
+            dialect.enable_load_after_statement = true;
+        }
+        dialect
+    }
 
     pub(crate) fn new(
         mode: ContextMode,
@@ -372,7 +388,7 @@ impl<'v> BazelContext<'v> {
     ) -> EvalResult<impl Iterator<Item = EvalMessage> + use<>> {
         Self::err(
             filename,
-            AstModule::parse(filename, content, &self.dialect)
+            AstModule::parse(filename, content, &self.dialect_for_file(filename))
                 .map(|module| self.go(filename, module))
                 .map_err(Into::into),
         )
@@ -626,6 +642,66 @@ impl<'v> BazelContext<'v> {
                 .filter_map(|line| line.strip_prefix(module).map(|str| str.to_owned()))
                 .collect(),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use starlark::analysis::AstModuleLint;
+    use starlark::syntax::AstModule;
+    use starlark::syntax::Dialect;
+
+    use super::BazelContext;
+
+    #[test]
+    fn test_dialect_for_workspace_file_allows_load_after_statement() {
+        let context = BazelContext {
+            workspace_name: None,
+            external_output_base: None,
+            mode: crate::eval::ContextMode::Check,
+            print_non_none: false,
+            prelude: Vec::new(),
+            module: None,
+            dialect: Dialect::Standard,
+            globals: starlark::environment::Globals::standard(),
+            builtin_docs: Default::default(),
+            builtin_symbols: Default::default(),
+        };
+
+        assert!(
+            context
+                .dialect_for_file("/repo/WORKSPACE")
+                .enable_load_after_statement
+        );
+        assert!(
+            context
+                .dialect_for_file("/repo/WORKSPACE.bazel")
+                .enable_load_after_statement
+        );
+        assert!(
+            !context
+                .dialect_for_file("/repo/BUILD.bazel")
+                .enable_load_after_statement
+        );
+
+        let module = AstModule::parse(
+            "/repo/WORKSPACE",
+            r#"
+local_repository(
+    name = "x",
+)
+load("//:defs.bzl", "defs")
+"#
+            .to_owned(),
+            &context.dialect_for_file("/repo/WORKSPACE"),
+        )
+        .unwrap();
+        assert!(
+            module
+                .lint(None)
+                .into_iter()
+                .all(|lint| lint.short_name != "misplaced-load")
+        );
     }
 }
 

--- a/starlark_syntax/src/dialect.rs
+++ b/starlark_syntax/src/dialect.rs
@@ -57,6 +57,7 @@ pub struct Dialect {
     pub enable_load_reexport: bool,
     /// Are `load` statements allowed after other top-level statements.
     /// Disabled by default.
+    /// Currently only respected by lints.
     pub enable_load_after_statement: bool,
     /// Are `for`, `if` and other statements allowed at the top level.
     /// Disabled by default.

--- a/starlark_syntax/src/dialect.rs
+++ b/starlark_syntax/src/dialect.rs
@@ -55,6 +55,9 @@ pub struct Dialect {
     /// Enabled by default,
     /// but may change in future definitions of the standard.
     pub enable_load_reexport: bool,
+    /// Are `load` statements allowed after other top-level statements.
+    /// Disabled by default.
+    pub enable_load_after_statement: bool,
     /// Are `for`, `if` and other statements allowed at the top level.
     /// Disabled by default.
     pub enable_top_level_stmt: bool,
@@ -91,6 +94,7 @@ impl Dialect {
         enable_positional_only_arguments: false,
         enable_types: DialectTypes::Disable,
         enable_load_reexport: true, // But they plan to change it
+        enable_load_after_statement: false,
         enable_top_level_stmt: false,
         enable_f_strings: false,
         _non_exhaustive: (),
@@ -106,6 +110,7 @@ impl Dialect {
         enable_positional_only_arguments: false,
         enable_types: DialectTypes::Enable,
         enable_load_reexport: true,
+        enable_load_after_statement: false,
         enable_top_level_stmt: true,
         enable_f_strings: false,
         _non_exhaustive: (),
@@ -121,6 +126,7 @@ impl Dialect {
         enable_positional_only_arguments: true,
         enable_types: DialectTypes::Enable,
         enable_load_reexport: true,
+        enable_load_after_statement: false,
         enable_top_level_stmt: true,
         enable_f_strings: true,
         _non_exhaustive: (),


### PR DESCRIPTION
Fixes #145.

## Summary
This PR fixes a false-positive lint warning in Bazel workspace files.

`misplaced-load` currently warns when a `load(...)` is not at the top of a file.  
That behavior is useful for normal Starlark files, but it is noisy for `WORKSPACE` / `WORKSPACE.bazel`, where repository setup calls may legitimately appear before 
`load(...)`.

## Changes
- Skip `FlowIssue::MisplacedLoad` for files named:
 - `WORKSPACE`
 - `WORKSPACE.bazel`
- Keep existing `misplaced-load` behavior unchanged for all other files.
- Add focused tests in `starlark/src/analysis/flow.rs`:
 - `test_lint_misplaced_load_workspace`
 - `test_lint_misplaced_load_workspace_bazel`

## Validation
- `cargo test -p starlark test_lint_misplaced_load --lib`
- `cargo clippy`
- `cargo build`
- `cargo test`
- `cargo bench`