### PR TITLE
Improve newline behavior for single-line # comments

### DIFF
--- a/vscode/syntaxes/starlark.configuration.json
+++ b/vscode/syntaxes/starlark.configuration.json
@@ -2,6 +2,15 @@
     "comments": {
         "lineComment": "#"
     },
+    "onEnterRules": [
+        {
+            "beforeText": "^\\s*#.*$",
+            "action": {
+                "indentAction": "none",
+                "appendText": "# "
+            }
+        }
+    ],
     "brackets": [
         ["{", "}"],
         ["[", "]"],


### PR DESCRIPTION
Fixes #91.

This PR improves VSCode editing UX for Starlark by continuing single-line # comments when pressing Enter.

Change

- Added onEnterRules in vscode/syntaxes/starlark.configuration.json to append #  on newline after comment lines.

Validation

- cargo clippy
- cargo build
- cargo test
- cargo bench

Note

vscode TypeScript compile failure is currently reproducible on main due existing dependency/type mismatch and is not introduced by this PR.