### PR TITLE
Fix VSCode extension build after vscode-languageclient update

### DIFF
--- a/vscode/client/package-lock.json
+++ b/vscode/client/package-lock.json
@@ -14,11 +14,11 @@
 				"vscode-languageclient": "^9.0.1"
 			},
 			"devDependencies": {
-				"@types/vscode": "1.43.0",
+				"@types/vscode": "1.82.0",
 				"@vscode/test-electron": "^1.3.0"
 			},
 			"engines": {
-				"vscode": "^1.43.0"
+				"vscode": "^1.82.0"
 			}
 		},
 		"..": {
@@ -38,7 +38,7 @@
 				"typescript": "^4.4.3"
 			},
 			"engines": {
-				"vscode": "^1.43.0"
+				"vscode": "^1.82.0"
 			}
 		},
 		"node_modules/@tootallnate/once": {
@@ -51,10 +51,11 @@
 			}
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.43.0.tgz",
-			"integrity": "sha512-kIaR9qzd80rJOxePKpCB/mdy00mz8Apt2QA5Y6rdrKFn13QNFNeP3Hzmsf37Bwh/3cS7QjtAeGSK7wSqAU0sYQ==",
-			"dev": true
+			"version": "1.82.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
+			"integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@vscode/test-electron": {
 			"version": "1.6.2",
@@ -533,9 +534,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.43.0.tgz",
-			"integrity": "sha512-kIaR9qzd80rJOxePKpCB/mdy00mz8Apt2QA5Y6rdrKFn13QNFNeP3Hzmsf37Bwh/3cS7QjtAeGSK7wSqAU0sYQ==",
+			"version": "1.82.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
+			"integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
 			"dev": true
 		},
 		"@vscode/test-electron": {

--- a/vscode/client/package.json
+++ b/vscode/client/package.json
@@ -10,7 +10,7 @@
 		"url": "https://github.com/Microsoft/vscode-extension-samples"
 	},
 	"engines": {
-		"vscode": "^1.43.0"
+		"vscode": "^1.82.0"
 	},
 	"dependencies": {
 		"cd": "^0.3.3",
@@ -18,7 +18,7 @@
 		"vscode-languageclient": "^9.0.1"
 	},
 	"devDependencies": {
-		"@types/vscode": "1.43.0",
+		"@types/vscode": "1.82.0",
 		"@vscode/test-electron": "^1.3.0"
 	},
 	"overrides": {

--- a/vscode/client/src/extension.ts
+++ b/vscode/client/src/extension.ts
@@ -21,7 +21,7 @@ import {
     LanguageClient,
     LanguageClientOptions,
     ServerOptions,
-} from 'vscode-languageclient';
+} from 'vscode-languageclient/node';
 
 let client: LanguageClient;
 

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -21,7 +21,7 @@
                 "typescript": "^4.4.3"
             },
             "engines": {
-                "vscode": "^1.43.0"
+                "vscode": "^1.82.0"
             }
         },
         "node_modules/@azu/format-text": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -17,7 +17,7 @@
         "multi-root ready"
     ],
     "engines": {
-        "vscode": "^1.43.0"
+        "vscode": "^1.82.0"
     },
     "activationEvents": [
         "onLanguage:starlark"


### PR DESCRIPTION
Fixes #153.

This PR fixes the VSCode extension TypeScript build break caused by a version mismatch between vscode-languageclient v9 and older VSCode type definitions.

What changed

- Switched language client import to Node entrypoint:
- vscode/client/src/extension.ts
- from 'vscode-languageclient/node'
- Updated VSCode API/type alignment:
- vscode/client/package.json
 - @types/vscode → 1.82.0
 - engines.vscode → ^1.82.0
- vscode/package.json
 - engines.vscode → ^1.82.0
- Updated lockfiles:
- vscode/client/package-lock.json
- vscode/package-lock.json

Validation

- cd vscode && npm run compile passes
- cargo clippy
- cargo build
- cargo test
- cargo bench