### PR TITLE
Add docstrings to members of typing

### DIFF
--- a/starlark/src/values/typing/any.rs
+++ b/starlark/src/values/typing/any.rs
@@ -21,6 +21,9 @@ use starlark_derive::ProvidesStaticType;
 use starlark_derive::StarlarkPagable;
 
 use crate as starlark;
+use crate::docs::DocItem;
+use crate::docs::DocString;
+use crate::docs::DocType;
 use crate::static_starlark_value;
 use crate::typing::Ty;
 use crate::values::AllocFrozenValue;
@@ -42,6 +45,22 @@ pub(crate) struct TypingAny;
 
 #[starlark_value(type = "typing.Any")]
 impl<'v> StarlarkValue<'v> for TypingAny {
+    fn documentation(&self) -> DocItem {
+        DocItem::Type(DocType {
+            docs: DocString::from_docstring(
+                crate::docs::DocStringKind::Rust,
+                "\
+This type matches any type.
+
+Any value can be assigned to a name or parameter of this type.
+See also [`typing.Any` in the Python documentation][1].
+
+[1]: https://docs.python.org/3/library/typing.html#typing.Any",
+            ),
+            ..DocType::from_starlark_value::<Self>()
+        })
+    }
+
     fn eval_type(&self) -> Option<Ty> {
         Some(Ty::any())
     }

--- a/starlark/src/values/typing/callable.rs
+++ b/starlark/src/values/typing/callable.rs
@@ -32,6 +32,9 @@ use starlark_derive::StarlarkPagable;
 use starlark_derive::starlark_value;
 
 use crate as starlark;
+use crate::docs::DocItem;
+use crate::docs::DocString;
+use crate::docs::DocType;
 use crate::private::Private;
 use crate::static_starlark_value;
 use crate::typing::ParamSpec;
@@ -70,6 +73,34 @@ pub(crate) struct TypingCallable;
 
 #[starlark_value(type = "typing.Callable")]
 impl<'v> StarlarkValue<'v> for TypingCallable {
+    fn documentation(&self) -> DocItem {
+        DocItem::Type(DocType {
+            docs: DocString::from_docstring(
+                crate::docs::DocStringKind::Rust,
+                "\
+Type annotation for callable objects (e.g. functions).
+
+This is a generic type whose parameters indicate the argument types and return type of the object.
+
+# Examples
+
+```starlark
+def f(i: int, s: str) -> bool:
+...
+
+# would be matched by:
+
+typing.Callable[[int, str], bool]
+```
+
+See also [`typing.Callable` in the Python documentation][1].
+
+[1]: https://docs.python.org/3/library/typing.html#typing.Callable",
+            ),
+            ..DocType::from_starlark_value::<Self>()
+        })
+    }
+
     fn eval_type(&self) -> Option<Ty> {
         Some(StarlarkCallable::<StarlarkCallableParamAny, FrozenValue>::starlark_type_repr())
     }

--- a/starlark/src/values/typing/iter.rs
+++ b/starlark/src/values/typing/iter.rs
@@ -24,6 +24,9 @@ use starlark_derive::StarlarkPagable;
 use starlark_derive::starlark_value;
 
 use crate as starlark;
+use crate::docs::DocItem;
+use crate::docs::DocString;
+use crate::docs::DocType;
 use crate::static_starlark_value;
 use crate::typing::Ty;
 use crate::values::AllocFrozenValue;
@@ -58,6 +61,25 @@ pub(crate) struct TypingIterable;
 
 #[starlark_value(type = "typing.Iterable")]
 impl<'v> StarlarkValue<'v> for TypingIterable {
+    fn documentation(&self) -> DocItem {
+        DocItem::Type(DocType {
+            docs: DocString::from_docstring(
+                crate::docs::DocStringKind::Rust,
+                "\
+Represents a type that can be [iterated][1].
+
+`Iterable` takes one type argument, which may indicate the type of values yielded by the `Iterable`
+instance. Specifying the type to be iterated over is not currently supported.
+
+See also [`typing.Iterable` in the Python documentation][2].
+
+[1]: https://github.com/bazelbuild/starlark/blob/master/spec.md#iteration
+[2]: https://docs.python.org/3/library/typing.html#typing.Iterable",
+            ),
+            ..DocType::from_starlark_value::<Self>()
+        })
+    }
+
     fn eval_type(&self) -> Option<Ty> {
         Some(Ty::iter(Ty::any()))
     }

--- a/starlark/src/values/typing/never.rs
+++ b/starlark/src/values/typing/never.rs
@@ -38,6 +38,9 @@ use starlark_derive::ProvidesStaticType;
 use starlark_derive::StarlarkPagable;
 
 use crate as starlark;
+use crate::docs::DocItem;
+use crate::docs::DocString;
+use crate::docs::DocType;
 use crate::static_starlark_value;
 use crate::typing::Ty;
 use crate::values::AllocFrozenValue;
@@ -61,6 +64,26 @@ pub(crate) struct TypingNever;
 
 #[starlark_value(type = "typing.Never")]
 impl<'v> StarlarkValue<'v> for TypingNever {
+    fn documentation(&self) -> DocItem {
+        DocItem::Type(DocType {
+            docs: DocString::from_docstring(
+                crate::docs::DocStringKind::Rust,
+                "\
+This type can never be constructed.
+
+Equivalent to [Python's `typing.Never`][1], it is Starlark's representation
+of the [bottom type][2]. A function returning `typing.Never` will never
+return. A function taking an argument of `typing.Never` can never be called.
+
+See also [`typing.Never` in the Python documentation][1].
+
+[1]: https://docs.python.org/3/library/typing.html#typing.Never
+[2]: https://en.wikipedia.org/wiki/Bottom_type",
+            ),
+            ..DocType::from_starlark_value::<Self>()
+        })
+    }
+
     fn eval_type(&self) -> Option<Ty> {
         Some(Ty::never())
     }


### PR DESCRIPTION
Implementations of `StarlarkValue::documentation()` derived from actual Rust docstrings are not automatically generated by `#[starlark_value]`, but instead by `#[starlark_module]`. The typing module does not use `#[starlark_module]`, and introducing a second spot where Rust docstrings would be picked up for `Starlark::documentation()` seemed confusing, so this patch hand-rolls the function implementations.