### PR TITLE
Allow custom records types to be created from rust.

### DIFF
--- a/starlark/src/values/types/record.rs
+++ b/starlark/src/values/types/record.rs
@@ -48,5 +48,6 @@ pub(crate) mod matcher;
 pub(crate) mod record_type;
 pub(crate) mod ty_record_type;
 
+pub use crate::values::record::field::FieldGen;
 pub use crate::values::record::instance::Record;
 pub use crate::values::record::record_type::RecordType;

--- a/starlark/src/values/types/record/field.rs
+++ b/starlark/src/values/types/record/field.rs
@@ -51,8 +51,10 @@ use crate::values::typing::type_compiled::compiled::TypeCompiled;
     StarlarkPagable
 )]
 pub struct FieldGen<V: ValueLifetimeless> {
-    pub(crate) typ: TypeCompiled<V>,
-    pub(crate) default: Option<V>,
+    /// The expected type of the field.
+    pub typ: TypeCompiled<V>,
+    /// The default value (if provided).
+    pub default: Option<V>,
 }
 
 impl<'v, V: ValueLike<'v>> Display for FieldGen<V> {
@@ -73,10 +75,11 @@ unsafe impl<From: Coerce<To> + ValueLifetimeless, To: ValueLifetimeless> Coerce<
 {
 }
 
-starlark_complex_value!(pub(crate) Field);
+starlark_complex_value!(pub Field);
 
 impl<V: ValueLifetimeless> FieldGen<V> {
-    pub(crate) fn new(typ: TypeCompiled<V>, default: Option<V>) -> Self {
+    /// Creates a new `FieldGen`.
+    pub fn new(typ: TypeCompiled<V>, default: Option<V>) -> Self {
         Self { typ, default }
     }
 }

--- a/starlark/src/values/types/record/record_type.rs
+++ b/starlark/src/values/types/record/record_type.rs
@@ -161,7 +161,8 @@ pub(crate) fn record_fields<'v>(
 }
 
 impl<'v> RecordType<'v> {
-    pub(crate) fn new(fields: SmallMap<String, FieldGen<Value<'v>>>) -> Self {
+    /// Creates a new `RecordType`.
+    pub fn new(fields: SmallMap<String, FieldGen<Value<'v>>>) -> Self {
         Self {
             id: TypeInstanceId::r#gen(),
             fields,


### PR DESCRIPTION
This allows for a few things:
* Functions such as bazel's `provider` function can now be implemented in pure rust.
* Record objects can now be registered into globals (eg. bazel's DefaultInfo object)