### PR TITLE
fix index overflow in enumerate with large start

### DIFF
--- a/starlark/src/stdlib/funcs/other.rs
+++ b/starlark/src/stdlib/funcs/other.rs
@@ -166,7 +166,7 @@ pub(crate) fn register_other(builder: &mut GlobalsBuilder) {
             .get()
             .iterate(heap)?
             .enumerate()
-            .map(move |(k, v)| (k as i32 + start, v));
+            .map(move |(k, v)| (k as i64 + start as i64, v));
         Ok(AllocList(v))
     }
 
@@ -411,6 +411,14 @@ mod tests {
         assert::eq("1.23", "abs(-1.23)");
         assert::eq("2.3", "abs(2.3)");
         assert::is_true("isinstance(abs(1), int)");
+    }
+
+    #[test]
+    fn test_enumerate_start_overflow() {
+        assert::eq(
+            "enumerate(['a', 'b'], 2147483647)",
+            "[(2147483647, 'a'), (2147483648, 'b')]",
+        );
     }
 
     #[test]


### PR DESCRIPTION
**Index overflow in `enumerate` with a large start**

The per-element index is built as `k as i32 + start`, so when the caller passes a `start` near `i32::MAX` the addition overflows on the first elements rather than at some unreachable list length. Cause is doing the arithmetic in `i32` even though Starlark integers are arbitrary precision, so the correct result does not fit. Fix widens the running index to `i64` before adding the offset.

`enumerate(['a', 'b'], 2147483647)` panics with "attempt to add with overflow" in debug and wraps to a negative index in release; it should yield `[(2147483647, 'a'), (2147483648, 'b')]`. Added a regression test alongside the existing builtin tests.

Should be safe as the index can no longer exceed `i64` for any in-memory iterable, though a reviewer may prefer matching whatever width the range work settled on.