### PR TITLE
Make internal test modules conditional on #[cfg(test)]

### DIFF
--- a/pagable/src/lib.rs
+++ b/pagable/src/lib.rs
@@ -37,6 +37,7 @@ pub mod flavors;
 mod impls;
 mod pagable_arc;
 pub mod storage;
+#[cfg(test)]
 mod test;
 pub mod testing;
 pub mod traits;

--- a/starlark/src/analysis/unused_loads.rs
+++ b/starlark/src/analysis/unused_loads.rs
@@ -16,6 +16,8 @@
  */
 
 pub(crate) mod find;
+#[cfg(test)]
 mod find_tests;
 pub(crate) mod remove;
+#[cfg(test)]
 mod remove_tests;


### PR DESCRIPTION
This PR guards the internal test modules `find_tests` / `remove_tests` (in `starlark`) and `test` (in `pagable`) with `#[cfg(test)]`.

Pagable is particularly bad as the inner file is not guarded with cfg(test), so the test code actually compiles when you're depending on it. This also prevents being able to prune test files from disk when vendoring the code.