### PR TITLE
Allow aggressive GC in tests.

### DIFF
--- a/starlark/src/assert/assert.rs
+++ b/starlark/src/assert/assert.rs
@@ -250,6 +250,11 @@ impl<'a> Assert<'a> {
         self.gc_strategy = Some(GcStrategy::Never)
     }
 
+    /// Configure garbage collection to run aggressively.
+    pub fn always_gc(&mut self) {
+        self.gc_strategy = Some(GcStrategy::Always)
+    }
+
     /// Configure a callback which is used to setup evaluator before each evaluation.
     pub fn setup_eval(&mut self, setup: impl Fn(&mut Evaluator) + 'static) {
         self.setup_eval = Box::new(setup);


### PR DESCRIPTION
a.pass(...) runs the code three times, which doesn't work very well for code which is not hermetic (eg. if your starlark code mutates data structures).

This can be avoided via disable_gc, but this removes safety because you are no longer checking free-after-use errors from values being garbage collected.

This introduces a mechanism to ensure that the code only runs once, but does so with as much safety as possible.