### PR TITLE
Backport blake3 version change to pagable 0.4.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ ref-cast = "1.0.18"
 relative-path = { version = "1.7.0", features = ["serde"] }
 syn = { version = "2.0.117", features = ["full"] }
 
-pagable = { version = "0.4.1", path = "pagable" }
+pagable = { version = "0.4.2", path = "pagable" }
 # dependencies of pagable
 async-trait = "0.1.86"
 blake3 = { version = "1.8", features = ["default", "rayon", "std", "traits-preview"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ syn = { version = "2.0.117", features = ["full"] }
 pagable = { version = "0.4.1", path = "pagable" }
 # dependencies of pagable
 async-trait = "0.1.86"
-blake3 = { version = "=1.8.2", features = ["default", "rayon", "std", "traits-preview"] }
+blake3 = { version = "1.8", features = ["default", "rayon", "std", "traits-preview"] }
 bytemuck = { version = "1.25", features = ["const_zeroed", "derive", "min_const_generics", "must_cast", "nightly_stdsimd"] }
 dashmap = "6.1.0"
 indexmap = { version = "2.14.0", features = ["serde"] }

--- a/pagable/Cargo.toml
+++ b/pagable/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2024"
 license = { workspace = true }
 name = "pagable"
 repository = { workspace = true }
-version = "0.4.1"
+version = "0.4.2"
 
 [dependencies]
 allocative = { workspace = true }
@@ -21,7 +21,7 @@ indexmap = { workspace = true }
 inventory = { workspace = true }
 num-bigint = { workspace = true }
 once_cell = { workspace = true }
-pagable_derive = { version = "=0.4.1", path = "../pagable_derive" }
+pagable_derive = { version = "=0.4.2", path = "../pagable_derive" }
 parking_lot = { workspace = true }
 postcard = { workspace = true }
 regex = { workspace = true }

--- a/pagable_derive/Cargo.toml
+++ b/pagable_derive/Cargo.toml
@@ -4,7 +4,7 @@ description = "Implementation of derive(Pagable) for pagable crate"
 edition = "2024"
 license = { workspace = true }
 name = "pagable_derive"
-version = "0.4.1"
+version = "0.4.2"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
This PR releases `pagable` and `pagable_derive` 0.4.2 containing a backport of https://github.com/facebook/starlark-rust/commit/3bed1c40f93da22b8e251dd520dfb8d35bfe1fb7 back to the commit that 0.4.1 was published from.

The API of `pagable` in main is currently substantially different from 0.4.1 and would need to be released as 0.5.0.